### PR TITLE
Fix/baremetal storage node labeling for multiple nodes

### DIFF
--- a/policies/storage-nodes/templates/policy-storage-nodes-baremetal.yaml
+++ b/policies/storage-nodes/templates/policy-storage-nodes-baremetal.yaml
@@ -44,10 +44,12 @@ spec:
             {{ "{{hub-" }} end {{ "hub}}" }}
 
             # Build list with labels if labels exist
-            {{ "{{-" }} if not (eq 0 (len (list {{ "{{hub" }} range $label_list {{ "hub}}" }}{{ "{{hub" }} . | quote {{ "hub}}" }}{{ "{{hub" }} end {{ "hub}}" }}))) {{ "}}" }}
+            {{ "{{-" }} if not (eq 0 (len (list
+              {{ "{{hub" }} range $label_list {{ "hub}}" }} {{ "{{hub" }} . | quote {{ "hub}}" }} {{ "{{hub" }} end {{ "hub}}" }}))) {{ "}}" }}
 
               # Build node list from labels
-              {{ "{{-" }} range (list {{ "{{hub" }} range $label_list {{ "hub}}" }}{{ "{{hub" }} . | quote {{ "hub}}" }}{{ "{{hub" }} end {{ "hub}}" }}) {{ "}}" }}
+              {{ "{{-" }} range (list
+                {{ "{{hub" }} range $label_list {{ "hub}}" }} {{ "{{hub" }} . | quote {{ "hub}}" }} {{ "{{hub" }} end {{ "hub}}" }}) {{ "}}" }}
                 {{ "{{-" }} $nodes = append $nodes (lookup "v1" "Node" "" .) {{ "}}" }}
               {{ "{{-" }} end {{ "}}" }}
 


### PR DESCRIPTION
The existing policy for labeling baremetal storage nodes fails when having to label multiple nodes. It produces the following error:

`NonCompliant; violation - failed to parse the template JSON string # Declare the template to create the node labels {{- define "node_template" }} {{- range .nodes }} - complianceType: musthave objectDefinition: apiVersion: v1 kind: Node metadata: name: {{ .metadata.name }} labels: node-role.kubernetes.io/infra: '' cluster.ocs.openshift.io/openshift-storage: '' {{- end }} {{- end }} # Declare the node list to use with the template {{- $nodes := list }} # Build list of labels on hub # Build list with labels if labels exist {{- if not (eq 0 (len (list "node-m1""node-m2""node-m3"))) }} # Build node list from labels {{- range (list "node-m1""node-m2""node-m3") }} {{- $nodes = append $nodes (lookup "v1" "Node" "" .) }} {{- end }} # Call template {{- template "node_template" (dict "nodes" $nodes) }} # Build list with first 3 nodes instead of labels {{- else }} # Perform lookup of all nodes {{- $all_nodes := (lookup "v1" "Node" "" "").items }} # Build nodelist from number {{- range until 3 }} {{- $nodes = append $nodes (index $all_nodes .) }} {{- end }} # Call template {{- template "node_template" (dict "nodes" $nodes) }} {{- end }} : template: tmpl:22: unexpected "\"node-m1"... in operand
`

The issue was caused by the lack of spacing between loops in the template, which led to invalid JSON.

This change adds proper spacing between each loop, resolving the parsing errors and allowing multiple nodes to be labeled correctly.


