### PR TITLE
Add pyyaml rpm to fix script running

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -12,7 +12,8 @@ RUN dnf -y update &&\
         git \
         jq \
         ncurses \
-        procps-ng &&\
+        procps-ng \
+        python3-pyyaml &&\
     dnf clean all
 
 # Download oc


### PR DESCRIPTION
The `scripts/generate-operator-policy.sh` script was failing to run in the devcontainer because it did not have the `yaml` python module to import. This PR just adds that library.