### PR TITLE
fix: CA bundle ConfigMap name

### DIFF
--- a/policies/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
+++ b/policies/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
@@ -32,7 +32,7 @@ spec:
                 kind: ConfigMap
                 metadata:
                   namespace: {{ .Values.gitops.argoNamespace }}
-                  name: cluster-ca-bundle
+                  name: user-ca-bundle
                   labels:
                     config.openshift.io/inject-trusted-cabundle: "true"
 ---


### PR DESCRIPTION
ArgoCD ConfigMap name in the AutoShift policy was cluster-ca-bundle, but was user-ca-bundle everywhere else. Now it is all user-ca-bundle