### PR TITLE
Add OdhDashboardConfig settings to RHOAI policy

### DIFF
--- a/policies/rhoai/templates/policy-rhoai-config.yaml
+++ b/policies/rhoai/templates/policy-rhoai-config.yaml
@@ -87,6 +87,44 @@ spec:
                       managementState: '{{ "{{hub" }} index .ManagedClusterLabels "autoshift.io/rhoai-trustyai" | default "{{ .Values.rhoai.dsc.trustyai }}" {{ "hub}}" }}'
                     workbenches:
                       managementState: '{{ "{{hub" }} index .ManagedClusterLabels "autoshift.io/rhoai-workbenches" | default "{{ .Values.rhoai.dsc.workbenches }}" {{ "hub}}" }}'
+    # OdhDashboardConfig - customize dashboard settings
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: rhoai-dashboard-config
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: opendatahub.io/v1alpha
+                kind: OdhDashboardConfig
+                metadata:
+                  name: odh-dashboard-config
+                  namespace: {{ .Values.rhoai.dsci.applicationsNamespace }}
+                  labels:
+                    app: rhods-dashboard
+                    app.kubernetes.io/part-of: rhods-dashboard
+                    app.opendatahub.io/rhods-dashboard: 'true'
+                    platform.opendatahub.io/part-of: dashboard
+                spec:
+                  dashboardConfig:
+                    disableTracking: {{ .Values.rhoai.dashboard.disableTracking | default false }}
+                    disableModelRegistry: {{ .Values.rhoai.dashboard.disableModelRegistry | default false }}
+                    disableModelCatalog: {{ .Values.rhoai.dashboard.disableModelCatalog | default false }}
+                    disableKServeMetrics: {{ .Values.rhoai.dashboard.disableKServeMetrics | default false }}
+                    genAiStudio: {{ .Values.rhoai.dashboard.genAiStudio | default true }}
+                    modelAsService: {{ .Values.rhoai.dashboard.modelAsService | default true }}
+                    disableLMEval: {{ .Values.rhoai.dashboard.disableLMEval | default false }}
+                  hardwareProfileOrder: []
+                  notebookController:
+                    enabled: {{ .Values.rhoai.dashboard.notebookControllerEnabled | default true }}
+                    notebookNamespace: {{ .Values.rhoai.dashboard.notebookNamespace | default "rhods-notebooks" }}
+                    pvcSize: {{ .Values.rhoai.dashboard.pvcSize | default "20Gi" }}
+                  templateDisablement: []
+                  templateOrder: []
     # Status check - verify DSCInitialization is ready
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1

--- a/policies/rhoai/values.yaml
+++ b/policies/rhoai/values.yaml
@@ -40,6 +40,23 @@ rhoai:
     trainingoperator: Managed
     trustyai: Managed
 
+  # OdhDashboardConfig settings
+  dashboard:
+    # Tracking and analytics
+    disableTracking: false
+    # Model features
+    disableModelRegistry: false
+    disableModelCatalog: false
+    disableKServeMetrics: false
+    # GenAI features
+    genAiStudio: true
+    modelAsService: true
+    disableLMEval: false
+    # Notebook controller
+    notebookControllerEnabled: true
+    notebookNamespace: rhods-notebooks
+    pvcSize: 20Gi
+
 # hubClusterSets:
 #   hub:
 #     labels:


### PR DESCRIPTION
- Introduced new dashboard configuration options in values.yaml for tracking, model features, GenAI features, and notebook controller settings.
- Updated policy-rhoai-config.yaml to enforce the new dashboard settings through a ConfigurationPolicy for OdhDashboardConfig.