### PR TITLE
Enhance RHOAI policy documentation and configuration

### DIFF
--- a/policies/rhoai/templates/policy-rhoai-config.yaml
+++ b/policies/rhoai/templates/policy-rhoai-config.yaml
@@ -49,28 +49,25 @@ spec:
                     managementState: '{{ "{{hub" }} index .ManagedClusterLabels "autoshift.io/rhoai-servicemesh" | default "{{ .Values.rhoai.dsci.serviceMeshState }}" {{ "hub}}" }}'
                   trustedCABundle:
                     managementState: '{{ "{{hub" }} index .ManagedClusterLabels "autoshift.io/rhoai-trustedca" | default "{{ .Values.rhoai.dsci.trustedCABundleState }}" {{ "hub}}" }}'
-    # DataScienceCluster - Phase 1: Create with empty specs (RHOAI 3.0 workaround)
-    # RHOAI 3.0 webhook rejects 'Managed' on CREATE but allows on PATCH
+    # DataScienceCluster Bootstrap - create with empty spec first (RHOAI 3.0 workaround)
+    # RHOAI 3.0 webhook rejects 'managementState: Managed' on CREATE but allows on PATCH
+    # This policy ensures the DSC exists, then rhoai-dsc will patch it with component states
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: rhoai-dsc-create
+          name: rhoai-dsc-bootstrap
         spec:
           remediationAction: enforce
           severity: high
           object-templates:
-            - complianceType: mustonlyhave
+            - complianceType: musthave
               objectDefinition:
                 apiVersion: datasciencecluster.opendatahub.io/v1
                 kind: DataScienceCluster
                 metadata:
                   name: {{ .Values.rhoai.dsc.name }}
-                spec:
-                  components:
-                    dashboard: {}
-                    workbenches: {}
-    # DataScienceCluster - Phase 2: Patch with desired component states
+    # DataScienceCluster - configure component states (runs after bootstrap)
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
- Added new ConfigurationPolicies for DataScienceCluster initialization and management, including `rhoai-dsc-bootstrap` and `rhoai-dsc`.
- Updated README.md to include detailed descriptions of new ConfigurationPolicies and their roles in RHOAI 3.0.
- Included troubleshooting steps for components stuck in "Removed" state and clarified management state handling for DataScienceCluster.
- Expanded values.yaml to incorporate new dashboard configuration options and model registry settings.