### PR TITLE
adding global observability

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -704,6 +704,11 @@ hubClusterSets:
       logging-source-namespace: openshift-marketplace
 
       # =======================================================================
+      # Global Observability (MultiCluster Observability on the global hub)
+      # =======================================================================
+      global-observability: 'false'         # hub only — enables MCO + spoke rollup policies
+
+      # =======================================================================
       # Cluster Observability Operator
       # =======================================================================
       coo: 'false'

--- a/policies/stable/global-observability/Chart.yaml
+++ b/policies/stable/global-observability/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: global-observability
+description: A Helm chart for Kubernetes
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: 0.0.1

--- a/policies/stable/global-observability/README.md
+++ b/policies/stable/global-observability/README.md
@@ -1,0 +1,228 @@
+# Global Observability Policy
+
+Deploys and configures ACM MultiCluster Observability (MCO) on a global hub cluster, enabling centralized metrics collection from regional hubs via Thanos and Prometheus remote-write.
+
+## Policies
+
+| Policy | Description |
+|--------|-------------|
+| `policy-global-observability-mch` | Enables the `multicluster-observability` component on the MultiClusterHub |
+| `policy-global-observability-config` | Creates the MCO namespace, pull-secret, CA bundle secret, and Thanos object-storage secret |
+| `policy-global-observability-instance` | Creates the `MultiClusterObservability` CR with retention, storage, and addon settings |
+| `policy-global-observability-secrets` | Builds the `global-observability-secrets` Secret containing mTLS certs and the observatorium API URL |
+| `policy-global-observability-prometheus` | Patches PrometheusAgent templates on hub clusters with the built-in global hub rollup and any additional remote-write targets from rendered-config |
+
+## PolicySets and Placement
+
+| PolicySet | Targets | Placement Criteria |
+|-----------|---------|-------------------|
+| `policyset-global-observability-secrets` | Global hub only | `global-observability: 'true'` AND `self-managed: 'true'` |
+| `policyset-global-observability` | All hub clusters | `global-observability: 'true'` |
+| `policyset-global-observability-prometheus` | All hub clusters | `global-observability: 'true'` |
+
+## Labels
+
+All labels are prefixed with `autoshift.io/`.
+
+### Enable/Disable
+
+| Label | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global-observability` | bool | `'false'` | Enable MultiCluster Observability on hub clusters |
+
+### Placement Labels (used by PolicySet selectors)
+
+| Label | Type | Description |
+|-------|------|-------------|
+| `self-managed` | bool | Distinguishes the global hub (`'true'`) from regional hubs (`'false'`). Controls which PolicySets target which hubs. |
+
+### Configuration Labels
+
+| Label | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global-observability-storage-class` | string | cluster default | Storage class for Thanos persistent volumes |
+| `global-observability-retention-raw` | string | `'5d'` | Retention period for raw resolution metrics |
+| `global-observability-retention-5m` | string | `'14d'` | Retention period for 5-minute resolution metrics |
+| `global-observability-retention-1h` | string | `'30d'` | Retention period for 1-hour resolution metrics |
+| `global-observability-alertmanager-storage-size` | string | `'10Gi'` | Alertmanager PVC size |
+| `global-observability-compact-storage-size` | string | `'10Gi'` | Compactor PVC size |
+| `global-observability-receive-storage-size` | string | `'10Gi'` | Receiver PVC size |
+| `global-observability-rule-storage-size` | string | `'10Gi'` | Rule PVC size |
+| `global-observability-store-storage-size` | string | `'10Gi'` | Store gateway PVC size |
+
+## Chart Values (`globalObservability.*`)
+
+### General
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `namespace` | string | `open-cluster-management-observability` | Namespace where MCO resources are created |
+
+### CA Bundle
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `caBundle.sourceName` | string | `user-ca-bundle` | ConfigMap name in `openshift-config` containing the CA bundle |
+| `caBundle.sourceKey` | string | `ca-bundle.crt` | Key within the ConfigMap holding the CA certificate |
+
+### Thanos Object Storage
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `thanosStorage.bucket` | string | `acm-dr` | S3 bucket name for Thanos metrics storage |
+| `thanosStorage.endpoint` | string | `""` | S3 endpoint hostname (e.g. `s3.example.com`) |
+| `thanosStorage.insecure` | bool | `false` | Whether to skip TLS verification for the S3 endpoint |
+| `thanosStorage.source.namespace` | string | `""` | Namespace of the source secret containing S3 credentials |
+| `thanosStorage.source.secretName` | string | `""` | Name of the source secret containing S3 credentials |
+| `thanosStorage.source.accessKeyField` | string | `AWS_ACCESS_KEY_ID` | Key in the source secret holding the access key |
+| `thanosStorage.source.secretKeyField` | string | `AWS_SECRET_ACCESS_KEY` | Key in the source secret holding the secret key |
+
+### Retention and Storage
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `retentionResolutionRaw` | string | `5d` | Retention for raw resolution metrics |
+| `retentionResolution5m` | string | `14d` | Retention for 5-minute downsampled metrics |
+| `retentionResolution1h` | string | `30d` | Retention for 1-hour downsampled metrics |
+| `enableDownsampling` | bool | `true` | Enable Thanos downsampling of stored metrics |
+| `scrapeInterval` | string | `300s` | Prometheus scrape interval |
+| `scrapeSizeLimitBytes` | string | `1073741824` | Maximum scrape size in bytes (1 GiB) |
+| `workers` | int | `1` | Number of MCO addon workers |
+| `alertmanagerStorageSize` | string | `10Gi` | Alertmanager PVC size |
+| `compactStorageSize` | string | `10Gi` | Compactor PVC size |
+| `receiveStorageSize` | string | `10Gi` | Receiver PVC size |
+| `ruleStorageSize` | string | `10Gi` | Rule PVC size |
+| `storeStorageSize` | string | `10Gi` | Store gateway PVC size |
+
+### Spoke Agent
+
+Controls how hub clusters forward metrics via PrometheusAgent remote-write.
+
+#### Global Hub Rollup
+
+Built-in remote-write that forwards metrics from regional hubs to the self-managed hub's observatorium. Always deployed, automatically skipped on the self-managed hub (MCOA handles local writes).
+
+| Value | Type | Default | Description |
+|-------|------|---------|-------------|
+| `spokeAgent.prometheusAgentNames` | list | `[mcoa-default-platform-metrics-collector-global, mcoa-default-user-workload-metrics-collector-global]` | PrometheusAgent resources to patch on hubs |
+| `spokeAgent.globalHubRollup.name` | string | `acm-global-observability` | Name of the built-in remote-write entry |
+| `spokeAgent.globalHubRollup.secretName` | string | `global-observability-secrets` | Coalesced secret created by `policy-global-observability-secrets` |
+| `spokeAgent.globalHubRollup.secretNamespace` | string | `open-cluster-policies` | Namespace where the coalesced secret lives on the hub |
+| `spokeAgent.globalHubRollup.remoteTimeout` | string | `30s` | Timeout for remote-write requests |
+| `spokeAgent.globalHubRollup.caFile` | string | `/etc/prometheus/secrets/global-observability-secrets/ca.crt` | Path to the CA file inside the PrometheusAgent pod |
+| `spokeAgent.globalHubRollup.certFile` | string | `/etc/prometheus/secrets/global-observability-secrets/tls.crt` | Path to the client cert file |
+| `spokeAgent.globalHubRollup.keyFile` | string | `/etc/prometheus/secrets/global-observability-secrets/tls.key` | Path to the client key file |
+
+#### Additional Remote-Writes (rendered-config)
+
+Optional list of extra remote-write targets configured per-cluster/clusterset via the rendered-config ConfigMap under `globalObservability.additionalRemoteWrites`. These are added alongside the built-in rollup. Secrets are always replicated from the hub via `copySecretData`.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `additionalRemoteWrites[].name` | string | — | Name of the remote-write entry |
+| `additionalRemoteWrites[].url` | string | — | Remote-write endpoint URL |
+| `additionalRemoteWrites[].remoteTimeout` | string | `30s` | Timeout for remote-write requests |
+| `additionalRemoteWrites[].onSelfManagedHub` | bool | `false` | When true, emit on the self-managed hub too |
+| `additionalRemoteWrites[].caFile` | string | — | CA file path in the PrometheusAgent pod |
+| `additionalRemoteWrites[].certFile` | string | — | Client cert file path |
+| `additionalRemoteWrites[].keyFile` | string | — | Client key file path |
+| `additionalRemoteWrites[].secretRef.name` | string | — | Secret name to replicate into the observability namespace |
+| `additionalRemoteWrites[].secretRef.namespace` | string | — | Source namespace of the secret on the hub |
+
+## Dependencies
+
+| Policy | Depends On |
+|--------|-----------|
+| `policy-global-observability-prometheus` | `policy-global-observability-instance`, `policy-coo-operator-install` |
+
+## Prerequisites
+
+- The MultiClusterHub must have `multicluster-observability` enabled (handled by the MCH policy)
+- A source secret with S3 credentials must exist at the location specified by `thanosStorage.source.*`
+- A CA bundle ConfigMap must exist in `openshift-config` (specified by `caBundle.*`)
+- For spoke agent functionality: the Cluster Observability Operator must be installed on hub clusters
+- For additional remote-writes: referenced secrets must exist on the hub in their specified namespace
+
+## Examples
+
+### Labels Only
+
+```yaml
+# In autoshift/values/clustersets/hub.yaml
+hubClusterSets:
+  global-hub:
+    labels:
+      global-observability: 'true'
+      self-managed: 'true'
+      global-observability-storage-class: gp3-csi
+      global-observability-retention-raw: '7d'
+
+  regional-hub:
+    labels:
+      global-observability: 'true'
+      self-managed: 'false'
+```
+
+### Labels with Config
+
+```yaml
+# In autoshift/values/clustersets/hub.yaml or autoshift/values/clusters/<cluster>.yaml
+hubClusterSets:
+  global-hub:
+    labels:
+      global-observability: 'true'
+      self-managed: 'true'
+    config:
+      globalObservability:
+        useAlternateCA: false
+        storageClass: 'gp3-csi'
+        retentionResolutionRaw: '7d'
+        retentionResolution5m: '14d'
+        retentionResolution1h: '30d'
+        enableDownSampling: true
+        interval: 300
+        scrapeSizeLimitBytes: 1073741824
+        scrapeWorkers: 1
+        scrapeInterval: '300s'
+        logLevel: 'warn'
+        alertmanagerStorageSize: '10Gi'
+        compactStorageSize: '10Gi'
+        receiveStorageSize: '10Gi'
+        ruleStorageSize: '10Gi'
+        storeStorageSize: '10Gi'
+        capabilities:
+          platformAnalytics: 'true'
+          platformLogs: 'true'
+          platformMetrics: 'true'
+          userWorkloadLogs: 'true'
+          userWorkloadMetrics: 'true'
+          userWorkloadTraces: 'true'
+        thanosStorage:
+          bucket: 'acm-dr'
+          endpoint: 's3.example.com'
+          insecure: false
+          caBundle:
+            sourceName: 'user-ca-bundle'
+            sourceKey: 'ca-bundle.crt'
+          source:
+            namespace: 'my-secrets-ns'
+            secretName: 'my-s3-secret'
+            accessKeyField: 'AWS_ACCESS_KEY_ID'
+            secretKeyField: 'AWS_SECRET_ACCESS_KEY'
+        additionalRemoteWrites:
+          - name: external-monitoring
+            remoteTimeout: 30s
+            onSelfManagedHub: true
+            url: https://external.example.com/api/v1/receive
+            caFile: /etc/prometheus/secrets/external-certs/ca.crt
+            certFile: /etc/prometheus/secrets/external-certs/tls.crt
+            keyFile: /etc/prometheus/secrets/external-certs/tls.key
+            secretRef:
+              name: external-certs
+              namespace: some-ns
+
+  regional-hub:
+    labels:
+      global-observability: 'true'
+      self-managed: 'false'
+```

--- a/policies/stable/global-observability/architecture.md
+++ b/policies/stable/global-observability/architecture.md
@@ -1,0 +1,162 @@
+# Global Observability — Architecture Reference
+
+## MCOA PrometheusAgent Replication Flow
+
+MCOA (MultiCluster Observability Addon) manages the lifecycle of PrometheusAgent resources:
+
+1. **Hub-side templates**: MCOA creates PrometheusAgent resources in `open-cluster-management-observability` on each hub. These serve as templates defining the scrape and remote-write configuration for that hub's managed clusters.
+2. **Replication to managed clusters**: MCOA copies the PrometheusAgent from the hub's `open-cluster-management-observability` namespace to each managed cluster's `open-cluster-management-addon` namespace.
+3. **Secret replication**: Any secret listed in the PrometheusAgent's `spec.secrets` is automatically copied by MCOA from `open-cluster-management-observability` (on the hub) to `open-cluster-management-addon` (on the managed cluster). Secrets only need to exist in the hub's observability namespace — MCOA handles the last mile.
+
+## Hub Topology
+
+```
+Global Hub (self-managed=true)
+├── Runs MCO + Thanos + Observatorium (the global observability stack)
+├── MCOA creates PrometheusAgent templates for its managed clusters
+├── Managed clusters already write to this hub's observatorium via MCOA defaults
+│
+├── Regional Hub A (self-managed=false, managed by global hub)
+│   ├── Also runs MCO + MCOA for its own managed clusters
+│   ├── MCOA creates PrometheusAgent templates for its managed clusters
+│   └── Needs additional remote-write to forward metrics UP to the global hub
+│
+└── Regional Hub B (self-managed=false, managed by global hub)
+    └── Same as Regional Hub A
+```
+
+## Policy Chain
+
+Policies execute in dependency order. Each depends on the previous completing successfully.
+
+### Phase 1: Enable MCO on Hub (`policy-global-observability-mch`)
+
+- **Placement**: All hubs with `global-observability: 'true'` (via `policyset-global-observability`)
+- **Depends on**: `policy-acm-mch-install`
+- **Action**: Patches the MultiClusterHub CR to enable the `multicluster-observability` component
+- **Effect**: MCO operator starts, creates the observability namespace and its controllers
+
+### Phase 2: Prerequisite Resources (`policy-global-observability-config`)
+
+- **Placement**: All hubs with `global-observability: 'true'` (via `policyset-global-observability`)
+- **Depends on**: `policy-global-observability-mch`
+- **Action**: Creates resources in `open-cluster-management-observability`:
+  - Namespace (with cluster-monitoring label)
+  - Pull secret (copied from `openshift-config/pull-secret`)
+  - CA bundle secret (conditionally, from `openshift-config/<configurable>` when `useAlternateCA` is set in rendered-config)
+  - `thanos-object-storage` secret (S3 credentials copied from a source secret, bucket/endpoint from rendered-config)
+- **Template resolution**: Uses mixed hub templates (for rendered-config lookups) and regular templates (for on-cluster secret reads). The hub resolves config values, the managed cluster resolves the actual secret data.
+
+### Phase 3: MCO Instance (`policy-global-observability-instance`)
+
+- **Placement**: All hubs with `global-observability: 'true'` (via `policyset-global-observability`)
+- **Depends on**: `policy-global-observability-config`
+- **Action**: Creates the `MultiClusterObservability` CR with:
+  - Retention settings (raw, 5m, 1h)
+  - Storage sizes (alertmanager, compact, receive, rule, store)
+  - Storage class (optional)
+  - Addon scrape settings (interval, size limit, workers)
+  - MCOA capabilities toggles (platform analytics/logs/metrics, user workload logs/metrics/traces)
+- **Config source**: All values from rendered-config `globalObservability` key, falling back to Helm values defaults
+- **Effect**: MCO creates the Thanos stack, observatorium, and MCOA starts creating PrometheusAgent templates
+
+### Phase 4: Global Hub Secrets Assembly (`policy-global-observability-secrets`)
+
+- **Placement**: Self-managed hub only (`global-observability: 'true'` AND `self-managed: 'true'`, via `policyset-global-observability-secrets`)
+- **Depends on**: None (no explicit dependency, but MCO must be running for source secrets to exist)
+- **Action**: Assembles the coalesced `global-observability-secrets` secret in the **policy namespace** (`open-cluster-policies`) by reading from the self-managed hub's observability namespace:
+  - `tls.crt` / `tls.key` from the observability signer client cert
+  - `ca.crt` from `observability-managed-cluster-certs`
+  - `observatorium.url` discovered from the `observatorium-api` Route
+- **Why in the policy namespace?**: This secret is the source of truth that hub templates in the spoke policy will read via `copySecretData`. Placing it in the policy namespace makes it accessible to hub template resolution for all target clusters.
+- **Template type**: Regular templates (`{{ }}`) — these resolve on the self-managed hub itself (the managed cluster in ACM terms), reading secrets and routes that exist locally.
+
+### Phase 5: Spoke Agent — Secret Staging + PrometheusAgent Patching (`policy-global-observability-prometheus`)
+
+- **Placement**: All hubs with `global-observability: 'true'` (via `policyset-global-observability-prometheus`)
+- **Depends on**: `policy-global-observability-instance`, `policy-coo-operator-install`
+- **Two separate concerns:**
+
+#### 5a. Built-in global hub rollup
+
+Hardcoded in the template using `globalHubRollup` values. Not part of the generic remote-write list.
+
+**Secret replication** (`global-observability-rollup-secret` ConfigurationPolicy):
+- Copies the coalesced secret from its source namespace to `open-cluster-management-observability`
+- On self-managed hub: regular template `copySecretData` (local copy — secret exists on this cluster)
+- On regional hubs: hub template `copySecretData` (reads from the global hub's policy namespace)
+
+**PrometheusAgent patching**:
+- Adds the rollup secret to `spec.secrets` and the rollup remote-write entry to `spec.remoteWrite`
+- Skipped on self-managed hub (`if ne $isSelfManaged "true"`) — MCOA already handles local writes
+- URL resolved at runtime via `fromSecret` reading the `observatorium.url` key from the replicated secret
+
+#### 5b. Additional remote-writes (`additionalRemoteWrites`)
+
+Driven by the `additionalRemoteWrites` list in values. Each entry is independent.
+
+**Secret replication** (one `global-observability-secret-<name>` ConfigurationPolicy per secretRef):
+- `fromHub: true` — secret lives on the global hub. Self-managed hub copies locally (regular template), regional hubs copy from hub (hub template).
+- `fromHub: false` — secret exists locally on each hub. Always uses regular template `copySecretData`.
+
+**PrometheusAgent patching**:
+- Secrets and remote-write entries appended to the PrometheusAgent alongside the built-in rollup
+- Gated by `onSelfManagedHub`: when false (default), skipped on self-managed hub; when true, emitted everywhere
+
+## Secret Lifecycle
+
+```
+Self-Managed Hub                           Regional Hub
+────────────────                           ────────────
+open-cluster-management-observability:
+  ├─ observability-*-signer-client-cert
+  ├─ observability-managed-cluster-certs
+  └─ observatorium-api Route
+        │
+        ▼ (Phase 4: field-by-field
+           composition via regular
+           templates)
+open-cluster-policies:
+  └─ global-observability-secrets
+        │                                        │
+        ▼ (Phase 5a: regular template            ▼ (Phase 5a: hub template
+           copySecretData — local copy)             copySecretData — from hub)
+        │                                        │
+open-cluster-management-observability:   open-cluster-management-observability:
+  └─ global-observability-secrets          └─ global-observability-secrets
+        │                                        │
+        ▼ (MCOA replication)                     ▼ (MCOA replication)
+Managed Cluster:                         Managed Cluster:
+  open-cluster-management-addon:           open-cluster-management-addon:
+    └─ global-observability-secrets          └─ global-observability-secrets
+```
+
+## PolicySet Summary
+
+| PolicySet | Placement | Policies |
+|---|---|---|
+| `policyset-global-observability-secrets` | `global-observability: 'true'` + `self-managed: 'true'` | `policy-global-observability-secrets` |
+| `policyset-global-observability` | `global-observability: 'true'` (all hubs) | `policy-global-observability-mch`, `policy-global-observability-config`, `policy-global-observability-instance` |
+| `policyset-global-observability-prometheus` | `global-observability: 'true'` (all hubs) | `policy-global-observability-prometheus` |
+
+## `onSelfManagedHub` Logic (additionalRemoteWrites only)
+
+Each `additionalRemoteWrites` entry has an `onSelfManagedHub` flag:
+
+| `onSelfManagedHub` | Self-Managed Hub | Regional Hubs | Use Case |
+|---|---|---|---|
+| `false` (default) | Skipped | Emitted | Targets that only regional hubs should write to |
+| `true` | Emitted | Emitted | External targets that all hubs should write to |
+
+The built-in global hub rollup is always skipped on self-managed hub — this is not configurable, since MCOA handles local writes natively.
+
+The condition in the template: `if not (and (eq $isSelfManaged "true") (not <onSelfManagedHub>))` — emit unless we're on the self-managed hub AND the entry is NOT flagged for self-managed.
+
+## `fromHub` Logic (additionalRemoteWrites secretRefs)
+
+Each `secretRef` has a `fromHub` flag controlling where the secret is sourced:
+
+| `fromHub` | Self-Managed Hub | Regional Hubs | Use Case |
+|---|---|---|---|
+| `true` | Regular template (local copy) | Hub template (from global hub) | Secret assembled/stored on the global hub |
+| `false` (default) | Regular template (local copy) | Regular template (local copy) | Secret exists independently on each hub |

--- a/policies/stable/global-observability/global-observability-architecture.md
+++ b/policies/stable/global-observability/global-observability-architecture.md
@@ -1,0 +1,157 @@
+```mermaid
+graph TB
+    subgraph legend [" "]
+        direction LR
+        l1["🔵 ACM Policy"]
+        l2["🟢 K8s Resource Created"]
+        l3["🟡 ConfigMap / Pre-req"]
+        l4["⬜ External System"]
+    end
+
+    %% ================================================================
+    %% POLICY LAYER — dependency chain
+    %% ================================================================
+    subgraph policies ["Policy Dependency Chain"]
+        direction TB
+        ext_acm["policy-acm-mch-install\n(external dependency)"]
+
+        subgraph ps_main ["policyset-global-observability\n(Placement: autoshift.io/global-observability)"]
+            pol_mch["policy-global-observability-mch\nEnable MCH observability component"]
+            pol_config["policy-global-observability-config\nNamespace, pull-secret, CA bundle, thanos secret"]
+            pol_instance["policy-global-observability-instance\nMultiClusterObservability CR"]
+        end
+
+        subgraph ps_spoke ["policyset-global-observability-spoke-agent\n(Placement: autoshift.io/global-observability-spoke-agent)"]
+            pol_spoke["policy-global-observability-spoke-agent\nPatch PrometheusAgent on regional hubs"]
+        end
+
+        ext_acm -.->|"depends on"| pol_mch
+        pol_mch -.->|"depends on"| pol_config
+        pol_config -.->|"depends on"| pol_instance
+        pol_instance -.->|"depends on"| pol_spoke
+    end
+
+    rendered_config[("rendered-config\nConfigMap\n(per-cluster config)")]
+    rendered_config -.->|"hub template\nlookup"| pol_config
+    rendered_config -.->|"hub template\nlookup"| pol_instance
+
+    %% ================================================================
+    %% GLOBAL HUB — resources created by policies
+    %% ================================================================
+    subgraph global_hub ["Global Hub Cluster"]
+        subgraph ns_ocm ["namespace: open-cluster-management"]
+            mch["MultiClusterHub\nmulticlusterhub\n(multicluster-observability: enabled)"]
+        end
+
+        subgraph ns_mco ["namespace: open-cluster-management-observability"]
+            ns_res["Namespace\nopen-cluster-management-observability"]
+            pull_secret["Secret\nmulticlusterhub-operator-pull-secret"]
+            ca_bundle["Secret\nca-bundle\n(from openshift-config/user-ca-bundle)"]
+            thanos_secret["Secret\nthanos-object-storage\n(S3 creds from source secret)"]
+            mco_cr["MultiClusterObservability\nobservability"]
+        end
+
+        subgraph mco_spec ["MCO CR Spec"]
+            retention["retentionConfig\nraw: 5d | 5m: 14d | 1h: 30d"]
+            capabilities["capabilities\nplatform: analytics, logs, metrics, ui\nuserWorkloads: logs, metrics, traces"]
+            storage["storageConfig\nPVCs: alertmanager, compact,\nreceive, rule, store"]
+            addon["observabilityAddonSpec\nenableMetrics | interval: 300\nscrapeSizeLimitBytes | workers"]
+        end
+    end
+
+    %% Policy -> Resource creation edges
+    pol_mch ==>|"creates"| mch
+    pol_config ==>|"creates"| ns_res
+    pol_config ==>|"creates"| pull_secret
+    pol_config ==>|"creates"| ca_bundle
+    pol_config ==>|"creates"| thanos_secret
+    pol_instance ==>|"creates"| mco_cr
+
+    mco_cr --- retention
+    mco_cr --- capabilities
+    mco_cr --- storage
+    mco_cr --- addon
+
+    %% MCO CR references
+    mco_cr -.->|"imagePullSecret"| pull_secret
+    mco_cr -.->|"tlsSecretName"| ca_bundle
+    mco_cr -.->|"metricObjectStorage"| thanos_secret
+
+    %% ================================================================
+    %% EXTERNAL S3
+    %% ================================================================
+    s3[("External S3 Bucket\n(acm-dr)")]
+    thanos_secret -->|"TLS via\nca-bundle"| s3
+    mco_cr -->|"long-term\nmetric storage"| s3
+
+    %% ================================================================
+    %% OPENSHIFT-CONFIG (source secrets)
+    %% ================================================================
+    subgraph oc_config ["namespace: openshift-config (on hub)"]
+        oc_pull["Secret\npull-secret"]
+        oc_ca["ConfigMap\nuser-ca-bundle"]
+        oc_s3["Secret\n(S3 credentials source)"]
+    end
+
+    oc_pull -.->|"fromSecret"| pull_secret
+    oc_ca -.->|"fromConfigMap"| ca_bundle
+    oc_s3 -.->|"fromSecret"| thanos_secret
+
+    %% ================================================================
+    %% REGIONAL HUB — spoke agent target
+    %% ================================================================
+    subgraph regional_hub ["Regional Hub Cluster"]
+        subgraph ns_mco_reg ["namespace: open-cluster-management-observability"]
+            prom_agent["PrometheusAgent\n(MCOA-managed, patched by spoke-agent policy)"]
+            sec_certs["Secret\nglobal-observability-managed-cluster-certs\n(pre-replicated)"]
+            sec_signer["Secret\nglobal-observability-signer-cert\n(pre-replicated)"]
+        end
+
+        subgraph prom_spec ["PrometheusAgent Additions (via musthave patch)"]
+            rw_local["remoteWrite: acm-observability\n→ regional hub observatorium API"]
+            rw_global["remoteWrite: acm-global-observability\n→ global hub observatorium API"]
+            mounted_secrets["secrets:\n• global-observability-managed-cluster-certs\n• global-observability-signer-cert"]
+        end
+    end
+
+    pol_spoke ==>|"patches"| prom_agent
+
+    prom_agent --- rw_local
+    prom_agent --- rw_global
+    prom_agent --- mounted_secrets
+
+    prom_agent -.->|"mounts"| sec_certs
+    prom_agent -.->|"mounts"| sec_signer
+
+    %% ================================================================
+    %% METRIC FLOW
+    %% ================================================================
+    subgraph spoke_clusters ["Spoke Clusters (managed by regional hub)"]
+        spoke_prom["Prometheus Agent\n(MCO addon on spokes)"]
+    end
+
+    spoke_prom -->|"remoteWrite\n(local hub)"| rw_local
+    spoke_prom -->|"remoteWrite\n(global hub)"| rw_global
+    rw_local -->|"metrics"| regional_hub
+    rw_global -->|"metrics via mTLS"| mco_cr
+
+    %% ================================================================
+    %% STYLES
+    %% ================================================================
+    classDef policy fill:#dae8fc,stroke:#6c8ebf,stroke-width:2px,font-weight:bold
+    classDef resource fill:#d5e8d4,stroke:#82b366,stroke-width:2px
+    classDef configmap fill:#fff2cc,stroke:#d6b656,stroke-width:2px
+    classDef external fill:#f5f5f5,stroke:#666666,stroke-width:1px,stroke-dasharray: 5 5
+    classDef policySet fill:#e1d5e7,stroke:#9673a6,stroke-width:2px
+    classDef specBlock fill:#ffffff,stroke:#82b366,stroke-width:1px
+    classDef sourceNs fill:#f5f5f5,stroke:#cccccc,stroke-width:1px
+
+    class pol_mch,pol_config,pol_instance,pol_spoke policy
+    class ext_acm external
+    class mch,ns_res,pull_secret,ca_bundle,thanos_secret,mco_cr,prom_agent resource
+    class rendered_config,sec_certs,sec_signer configmap
+    class s3,oc_pull,oc_ca,oc_s3 external
+    class retention,capabilities,storage,addon,rw_local,rw_global,mounted_secrets specBlock
+    class spoke_prom resource
+    class ps_main,ps_spoke policySet
+```

--- a/policies/stable/global-observability/templates/policy-global-observability-mcoa.yaml
+++ b/policies/stable/global-observability/templates/policy-global-observability-mcoa.yaml
@@ -1,0 +1,107 @@
+# Patches the MultiClusterObservability CR on global hubs to enable MCOA
+# (Multi Cluster Observability Addon) capabilities — platform analytics,
+# logs, metrics, and user-workload logs/metrics/traces. Capability toggles
+# come from the rendered-config ConfigMap under the "globalObservability.capabilities"
+# key (defaults to all "true" from values.yaml).
+#
+# Base MCO CR (namespace, secrets, retention, storage) is owned by
+# policy-acm-observability — this policy merely musthave-patches the
+# capabilities block on top of that CR.
+#
+# Placement: via policyset-global-observability
+# Depends on: policy-acm-observability (MCO CR must exist first)
+#
+{{- $policyName := "policy-global-observability-mcoa" }}
+{{- $policyNamespace := .Values.policy_namespace }}
+
+{{- if .Values.hubClusterSets }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $policyNamespace }}
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management, CA Security Assessment and Authorization
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration, CA-7 Continuous Monitoring
+spec:
+{{ if (($.Values.autoshift).dryRun) }}
+  remediationAction: inform
+{{ end }}
+  disabled: false
+  dependencies:
+    - name: policy-acm-observability
+      namespace: {{ $policyNamespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: global-observability-mcoa
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates-raw: |
+            {{ "{{hub-" }} $obsConfig := index (index (fromConfigMap "{{ $policyNamespace }}" (print .ManagedClusterName ".rendered-config") "config" | default "{}") | fromYaml) "globalObservability" | default dict {{ "hub}}" }}
+            {{ "{{hub-" }} $capabilities := index $obsConfig "capabilities" | default dict {{ "hub}}" }}
+            {{ "{{hub-" }} $platformAnalytics := index $capabilities "platformAnalytics" | default "{{ .Values.globalObservability.capabilities.platformAnalytics | default "true" }}" {{ "hub}}" }}
+            {{ "{{hub-" }} $platformLogs := index $capabilities "platformLogs" | default "{{ .Values.globalObservability.capabilities.platformLogs | default "true" }}" {{ "hub}}" }}
+            {{ "{{hub-" }} $platformMetrics := index $capabilities "platformMetrics" | default "{{ .Values.globalObservability.capabilities.platformMetrics | default "true" }}" {{ "hub}}" }}
+            {{ "{{hub-" }} $userWorkloadLogs := index $capabilities "userWorkloadLogs" | default "{{ .Values.globalObservability.capabilities.userWorkloadLogs | default "true" }}" {{ "hub}}" }}
+            {{ "{{hub-" }} $userWorkloadMetrics := index $capabilities "userWorkloadMetrics" | default "{{ .Values.globalObservability.capabilities.userWorkloadMetrics | default "true" }}" {{ "hub}}" }}
+            {{ "{{hub-" }} $userWorkloadTraces := index $capabilities "userWorkloadTraces" | default "{{ .Values.globalObservability.capabilities.userWorkloadTraces | default "true" }}" {{ "hub}}" }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: observability.open-cluster-management.io/v1beta2
+                kind: MultiClusterObservability
+                metadata:
+                  name: observability
+                spec:
+                  {{ "{{hub-" }} if or (eq $platformAnalytics "true") (eq $platformLogs "true") (eq $platformMetrics "true") (eq $userWorkloadLogs "true") (eq $userWorkloadMetrics "true") (eq $userWorkloadTraces "true") {{ "hub}}" }}
+                  capabilities:
+                    {{ "{{hub-" }} if or (eq $platformAnalytics "true") (eq $platformLogs "true") (eq $platformMetrics "true") {{ "hub}}" }}
+                    platform:
+                      {{ "{{hub" }} if eq $platformAnalytics "true" {{ "hub}}" }}
+                      analytics:
+                        incidentDetection: {}
+                        namespaceRightSizingRecommendation: {}
+                        virtualizationRightSizingRecommendation: {}
+                      {{ "{{hub" }} end {{ "hub}}" }}
+                      {{ "{{hub" }} if eq $platformLogs "true" {{ "hub}}" }}
+                      logs:
+                        collection: {}
+                      {{ "{{hub" }} end {{ "hub}}" }}
+                      {{ "{{hub" }} if eq $platformMetrics "true" {{ "hub}}" }}
+                      metrics:
+                        default:
+                          enabled: true
+                        ui: {}
+                      {{ "{{hub" }} end {{ "hub}}" }}
+                    {{ "{{hub-" }} end {{ "hub}}" }}
+                    {{ "{{hub-" }} if or (eq $userWorkloadLogs "true") (eq $userWorkloadMetrics "true") (eq $userWorkloadTraces "true") {{ "hub}}" }}
+                    userWorkloads:
+                      {{ "{{hub" }} if eq $userWorkloadLogs "true" {{ "hub}}" }}
+                      logs:
+                        collection:
+                          clusterLogForwarder: {}
+                      {{ "{{hub" }} end {{ "hub}}" }}
+                      {{ "{{hub" }} if eq $userWorkloadMetrics "true" {{ "hub}}" }}
+                      metrics:
+                        default:
+                          enabled: true
+                      {{ "{{hub" }} end {{ "hub}}" }}
+                      {{ "{{hub" }} if eq $userWorkloadTraces "true" {{ "hub}}" }}
+                      traces:
+                        collection:
+                          collector: {}
+                          instrumentation: {}
+                      {{ "{{hub" }} end {{ "hub}}" }}
+                    {{ "{{hub-" }} end {{ "hub}}" }}
+                  {{ "{{hub-" }} end {{ "hub}}" }}
+{{- end }}

--- a/policies/stable/global-observability/templates/policy-global-observability-prometheus-exists.yaml
+++ b/policies/stable/global-observability/templates/policy-global-observability-prometheus-exists.yaml
@@ -1,0 +1,60 @@
+# Inform-only gate: verifies the MCOA-managed PrometheusAgent templates
+# exist in the hub observability namespace before the patching policy runs.
+#
+# Rationale: the MCOA addon-manager pod only picks up PrometheusAgent
+# templates it created itself. If ACM creates them via a policy, the
+# addon controller will not replicate them (or their secrets) to managed
+# clusters. This policy only checks for existence — it never creates or
+# modifies the resources. Used as a Compliant dependency by
+# policy-global-observability-prometheus so the patching policy waits
+# for MCOA to produce the templates first.
+#
+# Placement: via policyset-global-observability-prometheus
+#
+{{- $policyName := "policy-global-observability-prometheus-exists" }}
+{{- $policyNamespace := .Values.policy_namespace }}
+{{- $mcoaPolicyName := "policy-global-observability-mcoa" }}
+{{- $prometheusAgentNames := .Values.globalObservability.spokeAgent.prometheusAgentNames | default (list "mcoa-default-platform-metrics-collector-global" "mcoa-default-user-workload-metrics-collector-global") }}
+
+{{- if .Values.hubClusterSets }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $policyNamespace }}
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management, CA Security Assessment and Authorization
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration, CA-7 Continuous Monitoring
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - name: {{ $mcoaPolicyName }}
+      namespace: {{ $policyNamespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: global-observability-prometheus-exists
+        spec:
+          remediationAction: inform
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates:
+          {{- range $name := $prometheusAgentNames }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: monitoring.rhobs/v1alpha1
+                kind: PrometheusAgent
+                metadata:
+                  name: {{ $name }}
+                  namespace: {{ $.Values.globalObservability.namespace }}
+          {{- end }}
+{{- end }}

--- a/policies/stable/global-observability/templates/policy-global-observability-prometheus-exists.yaml
+++ b/policies/stable/global-observability/templates/policy-global-observability-prometheus-exists.yaml
@@ -9,9 +9,9 @@
 # policy-global-observability-prometheus so the patching policy waits
 # for MCOA to produce the templates first.
 #
-# Placement: via policyset-global-observability-prometheus
+# Placement: via policyset-global-obs-prometheus
 #
-{{- $policyName := "policy-global-observability-prometheus-exists" }}
+{{- $policyName := "policy-global-obs-prometheus-exists" }}
 {{- $policyNamespace := .Values.policy_namespace }}
 {{- $mcoaPolicyName := "policy-global-observability-mcoa" }}
 {{- $prometheusAgentNames := .Values.globalObservability.spokeAgent.prometheusAgentNames | default (list "mcoa-default-platform-metrics-collector-global" "mcoa-default-user-workload-metrics-collector-global") }}

--- a/policies/stable/global-observability/templates/policy-global-observability-prometheus.yaml
+++ b/policies/stable/global-observability/templates/policy-global-observability-prometheus.yaml
@@ -1,0 +1,220 @@
+# Patches MCOA-managed PrometheusAgent templates on hub clusters to add
+# remote-write targets pointing to the global hub's observatorium API and
+# optionally to additional external endpoints.
+#
+# Two concerns:
+#   1. Built-in global hub rollup — hardcoded from globalHubRollup values,
+#      skipped on self-managed hub (MCOA already handles local writes).
+#   2. Additional remote-writes — driven by additionalRemoteWrites list,
+#      each with its own secrets, onSelfManagedHub, and fromHub controls.
+#
+# MCOA replicates PrometheusAgent templates + their spec.secrets from
+# open-cluster-management-observability on the hub to
+# open-cluster-management-addon on each managed cluster.
+#
+# WARNING: Secret names are translated to truncated mount names like
+# secret-<secret-name> cut off at 63 chars. If the cut occurs at a
+# non-alphanumeric character it will break the StatefulSet spec due to
+# RFC 1123 regex violations with no clear error message.
+#
+# Placement: via policyset-global-observability-prometheus
+# Depends on: policy-global-observability-mcoa, policy-coo-operator-install
+#
+{{- $policyName := "policy-global-observability-prometheus" }}
+{{- $policyNamespace := .Values.policy_namespace }}
+{{- $rollup := .Values.globalObservability.spokeAgent.globalHubRollup }}
+{{- $mcoaPolicyName := "policy-global-observability-mcoa" }}
+{{- $secretReplPolicyName := "policy-global-observability-secrets" }}
+
+{{- if .Values.hubClusterSets }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $policyNamespace }}
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management, CA Security Assessment and Authorization
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration, CA-7 Continuous Monitoring
+spec:
+{{ if (($.Values.autoshift).dryRun) }}
+  remediationAction: inform
+{{ end }}
+  disabled: false
+  dependencies:
+    - name: {{ $mcoaPolicyName }}
+      namespace: {{ $policyNamespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+      #    - name: {{ $secretReplPolicyName }}
+      #      namespace: {{ $policyNamespace }}
+      #      apiVersion: policy.open-cluster-management.io/v1
+      #      compliance: Compliant
+      #      kind: Policy
+    - name: policy-coo-operator-install
+      namespace: {{ $policyNamespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+    - name: policy-global-observability-prometheus-exists
+      namespace: {{ $policyNamespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+  policy-templates:
+    #####################################################################
+    # Built-in: replicate the coalesced global-observability secret
+    # from the hub's policy namespace to the observability namespace.
+    # On self-managed hub: Do nothing, the MCOA already handles this functionality
+    # On regional hubs: hub template copy (secret lives on the global hub).
+    #####################################################################
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: global-observability-rollup-secret-repl
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates-raw: |
+            # INDENTATION ANCHOR
+            {{ "{{hub" }} $isSelfManaged := (index .ManagedClusterLabels "autoshift.io/self-managed" | default "false") {{ "hub}}" }}
+            {{ "{{hub-" }} if ne $isSelfManaged "true" {{ "hub}}" }}
+                [
+                  {
+                    "complianceType": "musthave",
+                    "objectDefinition": {
+                      "kind": "Secret",
+                      "apiVersion": "v1",
+                      "metadata": {
+                        "name": "{{ $rollup.secretName }}",
+                        "namespace": "{{ $.Values.globalObservability.namespace }}",
+                      },
+                      "data": {{ "{{hub" }} copySecretData "{{ $rollup.secretNamespace }}" "{{ $rollup.secretName }}" {{ "hub}}" }},
+                      "type": "Opaque"
+
+                    }
+                  }
+                ]
+            {{ "{{hub-" }} end {{ "hub}}" }}
+
+    #####################################################################
+    # Additional: replicate secrets for each additionalRemoteWrites entry
+    # from the rendered-config ConfigMap
+    #####################################################################
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: global-observability-additional-secrets
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates-raw: |
+            # INDENTATION ANCHOR
+            {{ "{{hub" }} $obsConfig := index (index (fromConfigMap "{{ $policyNamespace }}" (print .ManagedClusterName ".rendered-config") "config" | default "{}") | fromYaml) "globalObservability" | default dict {{ "hub}}" }}
+            {{ "{{hub-" }} $additionalRW := index $obsConfig "additionalRemoteWrites" | default list {{ "hub}}" }}
+            {{ "{{hub-" }} $isSelfManaged := (index .ManagedClusterLabels "autoshift.io/self-managed" | default "false") {{ "hub}}" }}
+            {{ "{{hub-" }} range $rw := $additionalRW {{ "hub}}" }}
+              {{ "{{hub-" }} $secretRef := index $rw "secretRef" | default dict {{ "hub}}" }}
+              {{ "{{hub-" }} $onSelfManaged := index $rw "onSelfManagedHub" | default false {{ "hub}}" }}
+              {{ "{{hub-" }} if not (and (eq $isSelfManaged "true") (not $onSelfManaged)) {{ "hub}}" }}
+                {{ "{{hub-" }} if not (empty $secretRef) {{ "hub}}" }}
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: '{{ "{{hub" }} index $secretRef "name" {{ "hub}}" }}'
+                    namespace: {{ .Values.globalObservability.namespace }}
+                  type: Opaque
+                  data: '{{ "{{hub" }} copySecretData (index $secretRef "namespace") (index $secretRef "name") {{ "hub}}" }}'
+                {{ "{{hub-" }} end {{ "hub}}" }}
+              {{ "{{hub-" }} end {{ "hub}}" }}
+            {{ "{{hub-" }} end {{ "hub}}" }}
+
+    #####################################################################
+    # Patch PrometheusAgent templates with secrets + remoteWrite entries
+    #####################################################################
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: global-observability-prometheus
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates-raw: |
+            # INDENTATION ANCHOR
+            {{ "{{hub-" }} $obsConfig := index (index (fromConfigMap "{{ $policyNamespace }}" (print .ManagedClusterName ".rendered-config") "config" | default "{}") | fromYaml) "globalObservability" | default dict {{ "hub}}" }}
+            {{ "{{hub-" }} $scrapeInterval := index $obsConfig "scrapeInterval" | default "{{ .Values.globalObservability.scrapeInterval }}" {{ "hub}}" }}
+            {{ "{{hub-" }} $logLevel := index $obsConfig "logLevel" | default "{{ .Values.globalObservability.logLevel }}" | default "warn" {{ "hub}}" }}
+            {{ "{{hub-" }} $isSelfManaged := (index .ManagedClusterLabels "autoshift.io/self-managed" | default "false") {{ "hub}}" }}
+            {{ "{{hub-" }} $additionalRW := index $obsConfig "additionalRemoteWrites" | default list {{ "hub}}" }}
+            {{ range $idx, $name := (.Values.globalObservability.spokeAgent.prometheusAgentNames | default (list "mcoa-default-platform-metrics-collector-global" "mcoa-default-user-workload-metrics-collector-global")) }}
+            - complianceType: musthave
+              recreateOption: IfRequired
+              objectDefinition:
+                apiVersion: monitoring.rhobs/v1alpha1
+                kind: PrometheusAgent
+                metadata:
+                  name: {{ $name }}
+                  namespace: {{ $.Values.globalObservability.namespace }}
+                spec:
+                  scrapeInterval: {{ "{{hub" }} $scrapeInterval {{ "hub}}" }}
+                  logLevel: {{ "{{hub" }} $logLevel {{ "hub}}" }}
+                  secrets:
+                    # Built-in: global hub rollup secret — skipped on self-managed hub
+                    {{ "{{hub-" }} if ne $isSelfManaged "true" {{ "hub}}" }}
+                    - {{ $rollup.secretName }}
+                    {{ "{{hub-" }} end {{ "hub}}" }}
+                    # Additional: secrets from additionalRemoteWrites (rendered-config)
+                    {{ "{{hub-" }} range $rw := $additionalRW {{ "hub}}" }}
+                      {{ "{{hub-" }} $secretRef := index $rw "secretRef" | default dict {{ "hub}}" }}
+                      {{ "{{hub-" }} $onSelfManaged := index $rw "onSelfManagedHub" | default false {{ "hub}}" }}
+                      {{ "{{hub-" }} if not (and (eq $isSelfManaged "true") (not $onSelfManaged)) {{ "hub}}" }}
+                        {{ "{{hub-" }} if not (empty $secretRef) {{ "hub}}" }}
+                    - '{{ "{{hub" }} index $secretRef "name" {{ "hub}}" }}'
+                        {{ "{{hub-" }} end {{ "hub}}" }}
+                      {{ "{{hub-" }} end {{ "hub}}" }}
+                    {{ "{{hub-" }} end {{ "hub}}" }}
+                  remoteWrite:
+                    # Built-in: global hub rollup — skipped on self-managed hub
+                    {{ "{{hub-" }} if ne $isSelfManaged "true" {{ "hub}}" }}
+                    - name: {{ $rollup.name }}
+                      remoteTimeout: {{ $rollup.remoteTimeout }}
+                      tlsConfig:
+                        ca: {}
+                        caFile: {{ $rollup.caFile }}
+                        cert: {}
+                        certFile: {{ $rollup.certFile }}
+                        keyFile: {{ $rollup.keyFile }}
+                      url: '{{ "{{" }} fromSecret "{{ $.Values.globalObservability.namespace }}" "{{ $rollup.secretName }}" "observatorium.url" | base64dec {{ "}}" }}'
+                    {{ "{{hub-" }} end {{ "hub}}" }}
+                    # Additional remote-writes (rendered-config)
+                    {{ "{{hub-" }} range $rw := $additionalRW {{ "hub}}" }}
+                      {{ "{{hub-" }} $onSelfManaged := index $rw "onSelfManagedHub" | default false {{ "hub}}" }}
+                      {{ "{{hub-" }} if not (and (eq $isSelfManaged "true") (not $onSelfManaged)) {{ "hub}}" }}
+                    - name: '{{ "{{hub" }} index $rw "name" {{ "hub}}" }}'
+                      remoteTimeout: '{{ "{{hub" }} index $rw "remoteTimeout" | default "30s" {{ "hub}}" }}'
+                      tlsConfig:
+                        ca: {}
+                        caFile: '{{ "{{hub" }} index $rw "caFile" {{ "hub}}" }}'
+                        cert: {}
+                        certFile: '{{ "{{hub" }} index $rw "certFile" {{ "hub}}" }}'
+                        keyFile: '{{ "{{hub" }} index $rw "keyFile" {{ "hub}}" }}'
+                      url: '{{ "{{hub" }} index $rw "url" {{ "hub}}" }}'
+                      {{ "{{hub-" }} end {{ "hub}}" }}
+                    {{ "{{hub-" }} end {{ "hub}}" }}
+            {{- end }}
+{{- end }}

--- a/policies/stable/global-observability/templates/policy-global-observability-prometheus.yaml
+++ b/policies/stable/global-observability/templates/policy-global-observability-prometheus.yaml
@@ -17,7 +17,7 @@
 # non-alphanumeric character it will break the StatefulSet spec due to
 # RFC 1123 regex violations with no clear error message.
 #
-# Placement: via policyset-global-observability-prometheus
+# Placement: via policyset-global-obs-prometheus
 # Depends on: policy-global-observability-mcoa, policy-coo-operator-install
 #
 {{- $policyName := "policy-global-observability-prometheus" }}
@@ -57,7 +57,7 @@ spec:
       apiVersion: policy.open-cluster-management.io/v1
       compliance: Compliant
       kind: Policy
-    - name: policy-global-observability-prometheus-exists
+    - name: policy-global-obs-prometheus-exists
       namespace: {{ $policyNamespace }}
       apiVersion: policy.open-cluster-management.io/v1
       compliance: Compliant

--- a/policies/stable/global-observability/templates/policy-global-observability-secrets.yaml
+++ b/policies/stable/global-observability/templates/policy-global-observability-secrets.yaml
@@ -1,0 +1,54 @@
+---
+{{- $policyName := "policy-global-observability-secrets" }}
+{{- $policyNamespace := .Values.policy_namespace }}
+{{- $mcoaPolicyName := "policy-global-observability-mcoa" }}
+
+{{- if .Values.hubClusterSets }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $policyNamespace }}
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management, CA Security Assessment and Authorization
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration, CA-7 Continuous Monitoring
+spec:
+{{ if (($.Values.autoshift).dryRun) }}
+  remediationAction: inform
+{{ end }}
+  disabled: false
+  dependencies:
+    - name: {{ $mcoaPolicyName }}
+      namespace: {{ $policyNamespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: global-observability-rollup-secret
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates-raw: |
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Secret
+                metadata:
+                  name: {{ $.Values.globalObservability.spokeAgent.globalHubRollup.secretName }}
+                  namespace: {{ $.Values.policy_namespace }}
+                type: Opaque
+                data:
+                  tls.crt: '{{ "{{" }} fromSecret "open-cluster-management-observability" "observability-controller-open-cluster-management.io-observability-signer-client-cert" "tls.crt" {{ "}}" }}'
+                  tls.key: '{{ "{{" }} fromSecret "open-cluster-management-observability" "observability-controller-open-cluster-management.io-observability-signer-client-cert" "tls.key" {{ "}}" }}'
+                  ca.crt: '{{ "{{" }} fromSecret "open-cluster-management-observability" "observability-managed-cluster-certs" "ca.crt" {{ "}}" }}'
+                stringData:
+                  observatorium.url: 'https://{{ "{{" }} ((lookup "route.openshift.io/v1" "Route" "open-cluster-management-observability" "observatorium-api" | default dict).spec).host {{ "}}" }}/api/metrics/v1/default/api/v1/receive'
+{{ end }}

--- a/policies/stable/global-observability/templates/policysets.yaml
+++ b/policies/stable/global-observability/templates/policysets.yaml
@@ -1,0 +1,165 @@
+# PolicySets for Global Observability
+#
+# Groups global-observability policies by shared placement:
+#   - policyset-global-observability-secrets: global hub rollup secret creation (self-managed hub only)
+#   - policyset-global-observability: MCOA capabilities patch on MCO CR (all global-obs hubs)
+#   - policyset-global-observability-prometheus: PrometheusAgent remote-write patching
+#
+{{- if .Values.hubClusterSets }}
+##### GLOBAL HUB POLICY SET #####
+---
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: policyset-global-observability-secrets
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  description: policies that need to run on the global hub to replicate secrets
+  policies:
+    - policy-global-observability-secrets
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policyset-global-observability-secrets
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  clusterSets:
+  {{- range $clusterSet, $value := $.Values.hubClusterSets }}
+    - {{ $clusterSet }}
+  {{- end }}
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/global-observability'
+              operator: In
+              values:
+              - 'true'
+            - key: 'autoshift.io/self-managed'
+              operator: In
+              values:
+              - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: placement-policyset-global-observability-secrets
+  namespace: {{ $.Values.policy_namespace }}
+placementRef:
+  name: placement-policyset-global-observability-secrets
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: policyset-global-observability-secrets
+    apiGroup: policy.open-cluster-management.io
+    kind: PolicySet
+---
+##### ALL HUBS POLICY SET #####
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: policyset-global-observability
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  description: MCOA capabilities patched onto the base MultiClusterObservability CR
+  policies:
+    - policy-global-observability-mcoa
+---
+kind: Placement
+apiVersion: cluster.open-cluster-management.io/v1beta1
+metadata:
+  name: placement-policyset-global-observability
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  clusterSets:
+  {{- range $clusterSet, $value := $.Values.hubClusterSets }}
+    - {{ $clusterSet }}
+  {{- end }}
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/global-observability'
+              operator: In
+              values:
+              - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: placement-policyset-global-observability
+  namespace: {{ .Values.policy_namespace }}
+placementRef:
+  name: placement-policyset-global-observability
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: policyset-global-observability
+    apiGroup: policy.open-cluster-management.io
+    kind: PolicySet
+---
+##### PROMETHEUS CONFIG POLICY SET #####
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: policyset-global-observability-prometheus
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  description: global observability PrometheusAgent remote-write configuration on hub clusters
+  policies:
+    - policy-global-observability-prometheus-exists
+    - policy-global-observability-prometheus
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policyset-global-observability-prometheus
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  clusterSets:
+  {{- range $clusterSet, $value := $.Values.hubClusterSets }}
+    - {{ $clusterSet }}
+  {{- end }}
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/global-observability'
+              operator: In
+              values:
+              - 'true'
+            - key: 'autoshift.io/self-managed'
+              operator: In
+              values:
+              - 'false'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: placement-policyset-global-observability-prometheus
+  namespace: {{ .Values.policy_namespace }}
+placementRef:
+  name: placement-policyset-global-observability-prometheus
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: policyset-global-observability-prometheus
+    apiGroup: policy.open-cluster-management.io
+    kind: PolicySet
+{{- end }}

--- a/policies/stable/global-observability/templates/policysets.yaml
+++ b/policies/stable/global-observability/templates/policysets.yaml
@@ -3,7 +3,7 @@
 # Groups global-observability policies by shared placement:
 #   - policyset-global-observability-secrets: global hub rollup secret creation (self-managed hub only)
 #   - policyset-global-observability: MCOA capabilities patch on MCO CR (all global-obs hubs)
-#   - policyset-global-observability-prometheus: PrometheusAgent remote-write patching
+#   - policyset-global-obs-prometheus: PrometheusAgent remote-write patching
 #
 {{- if .Values.hubClusterSets }}
 ##### GLOBAL HUB POLICY SET #####
@@ -21,7 +21,7 @@ spec:
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-  name: placement-policyset-global-observability-secrets
+  name: placement-global-obs-secrets
   namespace: {{ .Values.policy_namespace }}
 spec:
   clusterSets:
@@ -49,10 +49,10 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: placement-policyset-global-observability-secrets
+  name: placement-global-obs-secrets
   namespace: {{ $.Values.policy_namespace }}
 placementRef:
-  name: placement-policyset-global-observability-secrets
+  name: placement-global-obs-secrets
   apiGroup: cluster.open-cluster-management.io
   kind: Placement
 subjects:
@@ -74,7 +74,7 @@ spec:
 kind: Placement
 apiVersion: cluster.open-cluster-management.io/v1beta1
 metadata:
-  name: placement-policyset-global-observability
+  name: placement-global-obs
   namespace: {{ .Values.policy_namespace }}
 spec:
   clusterSets:
@@ -98,10 +98,10 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: placement-policyset-global-observability
+  name: placement-global-obs
   namespace: {{ .Values.policy_namespace }}
 placementRef:
-  name: placement-policyset-global-observability
+  name: placement-global-obs
   apiGroup: cluster.open-cluster-management.io
   kind: Placement
 subjects:
@@ -113,18 +113,18 @@ subjects:
 apiVersion: policy.open-cluster-management.io/v1beta1
 kind: PolicySet
 metadata:
-  name: policyset-global-observability-prometheus
+  name: policyset-global-obs-prometheus
   namespace: {{ .Values.policy_namespace }}
 spec:
   description: global observability PrometheusAgent remote-write configuration on hub clusters
   policies:
-    - policy-global-observability-prometheus-exists
+    - policy-global-obs-prometheus-exists
     - policy-global-observability-prometheus
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
-  name: placement-policyset-global-observability-prometheus
+  name: placement-global-obs-prometheus
   namespace: {{ .Values.policy_namespace }}
 spec:
   clusterSets:
@@ -152,14 +152,14 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: placement-policyset-global-observability-prometheus
+  name: placement-global-obs-prometheus
   namespace: {{ .Values.policy_namespace }}
 placementRef:
-  name: placement-policyset-global-observability-prometheus
+  name: placement-global-obs-prometheus
   apiGroup: cluster.open-cluster-management.io
   kind: Placement
 subjects:
-  - name: policyset-global-observability-prometheus
+  - name: policyset-global-obs-prometheus
     apiGroup: policy.open-cluster-management.io
     kind: PolicySet
 {{- end }}

--- a/policies/stable/global-observability/values.yaml
+++ b/policies/stable/global-observability/values.yaml
@@ -1,0 +1,83 @@
+# Default values for global-observability.
+#
+# This chart owns the global-hub-specific pieces of MultiClusterObservability:
+#   * MCOA capability toggles (patches base MCO CR from policy-acm-observability)
+#   * PrometheusAgent remote-write patching (rollup to global hub + additional targets)
+#   * Global-hub rollup secret creation (self-managed hub)
+#
+# Base MCO lifecycle (namespace, pull secret, CA bundle, thanos-object-storage,
+# MCO CR with retention/storage/addon spec) is owned by policy-acm-observability
+# under the "acm.observability" key in the rendered-config ConfigMap.
+#
+policy_namespace: open-cluster-policies
+globalObservability:
+  namespace: open-cluster-management-observability
+  # MCOA capability toggles. Each accepts "true"/"false". Overridable per-cluster
+  # via rendered-config globalObservability.capabilities.*.
+  capabilities:
+    platformAnalytics: "true"
+    platformLogs: "true"
+    platformMetrics: "true"
+    userWorkloadLogs: "true"
+    userWorkloadMetrics: "true"
+    userWorkloadTraces: "true"
+  # Spoke PrometheusAgent scrape configuration
+  scrapeInterval: 300s
+  logLevel: warn
+  # Spoke agent — patches hub PrometheusAgent templates
+  spokeAgent:
+    # MCOA PrometheusAgent names to patch on hubs
+    prometheusAgentNames:
+      - mcoa-default-platform-metrics-collector-global
+      - mcoa-default-user-workload-metrics-collector-global
+    # Built-in global hub rollup — always deployed, skipped on self-managed hub
+    # Rolls up metrics from regional hubs to the self-managed hub's observatorium
+    globalHubRollup:
+      name: acm-global-observability
+      secretName: global-observability-secrets    # coalesced secret created by policy-global-observability-secrets
+      secretNamespace: policies-autoshift      # namespace where the coalesced secret lives on the hub
+      remoteTimeout: 30s
+      caFile: /etc/prometheus/secrets/global-observability-secrets/ca.crt
+      certFile: /etc/prometheus/secrets/global-observability-secrets/tls.crt
+      keyFile: /etc/prometheus/secrets/global-observability-secrets/tls.key
+    # Additional remote-write targets are configured per-cluster/clusterset
+    # via the rendered-config ConfigMap under globalObservability.additionalRemoteWrites.
+    # Secrets are always replicated from the hub via copySecretData.
+    #
+    # Example config block (in autoshift/values/clustersets/*.yaml or clusters/*.yaml):
+    #   config:
+    #     globalObservability:
+    #       additionalRemoteWrites:
+    #         - name: external-monitoring
+    #           remoteTimeout: 30s
+    #           onSelfManagedHub: true
+    #           url: https://external.example.com/api/v1/receive
+    #           caFile: /etc/prometheus/secrets/external-certs/ca.crt
+    #           certFile: /etc/prometheus/secrets/external-certs/tls.crt
+    #           keyFile: /etc/prometheus/secrets/external-certs/tls.key
+    #           secretRef:
+    #             name: external-certs
+    #             namespace: some-ns
+
+### AutoShift Labels Documentation
+# The following labels can be set at the cluster or clusterset level to configure this policy:
+#
+# Enable/Disable:
+# global-observability<bool>: 'true' or 'false' - Enable MCOA capabilities patching + rollup on the hub (default: 'false')
+#
+# Per-cluster overrides (via rendered-config ConfigMap under the "globalObservability" key):
+#   capabilities.{platformAnalytics,platformLogs,platformMetrics,
+#                 userWorkloadLogs,userWorkloadMetrics,userWorkloadTraces}: "true"|"false"
+#   scrapeInterval: '300s'
+#   logLevel: 'warn'
+#   additionalRemoteWrites: [...]
+#
+# Base MCO config (retention, storage, thanos, etc) lives under the "acm.observability"
+# key and is consumed by policy-acm-observability.
+#
+# Prerequisites:
+# - Cluster Observability Operator must be installed on reporting clusters
+# - policy-acm-observability must be Compliant (creates the base MCO CR and secrets)
+#
+# Examples:
+# autoshift.io/global-observability: 'true'

--- a/tools/testdata/observability-resources.yaml
+++ b/tools/testdata/observability-resources.yaml
@@ -1,0 +1,33 @@
+---
+# Signer client cert read by global-observability-rollup-secret via fromSecret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: observability-controller-open-cluster-management.io-observability-signer-client-cert
+  namespace: open-cluster-management-observability
+type: Opaque
+data:
+  tls.crt: dGVzdC1jZXJ0
+  tls.key: dGVzdC1rZXk=
+---
+# Managed cluster CA bundle read by global-observability-rollup-secret via fromSecret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: observability-managed-cluster-certs
+  namespace: open-cluster-management-observability
+type: Opaque
+data:
+  ca.crt: dGVzdC1jYQ==
+---
+# Observatorium ingress route used to derive observatorium.url via lookup.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: observatorium-api
+  namespace: open-cluster-management-observability
+spec:
+  host: observatorium-api-open-cluster-management-observability.apps.test-cluster.test.example.com
+  to:
+    kind: Service
+    name: observatorium-api


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] New policy (new operator or cluster configuration)
- [ ] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [ ] Other: <!-- describe -->

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
