### PR TITLE
Feature/external secrets operator

### DIFF
--- a/autoshift/values/clustersets/hubofhubs.yaml
+++ b/autoshift/values/clustersets/hubofhubs.yaml
@@ -153,7 +153,7 @@ hubClusterSets:
       coo-source: redhat-operators
       coo-source-namespace: openshift-marketplace
       ### Compliance Operator Stig Apply
-      compliance: 'true'
+      compliance: 'false'
       compliance-auto-remediate: 'true'
       compliance-subscription-name: compliance-operator
       compliance-source: redhat-operators

--- a/policies/stable/external-secrets-operator/README.md
+++ b/policies/stable/external-secrets-operator/README.md
@@ -80,6 +80,118 @@ Find available CSV versions:
 oc get packagemanifests external-secrets-operator -o jsonpath='{.status.channels[*].currentCSV}'
 ```
 
+## SecretStore / ClusterSecretStore Configuration
+
+Beyond installing the operator, this policy renders ESO `SecretStore` and `ClusterSecretStore`
+resources from per-cluster rendered-config ConfigMaps. Real config lives in cluster/clusterset
+values files under `config.eso.stores`; the stores policy reads each cluster's rendered-config
+at runtime and emits matching resources.
+
+### Enabling
+
+The single label `autoshift.io/external-secrets-operator: 'true'` opts a cluster into both the
+operator install policy and the stores policy. A cluster that has the label but no
+`config.eso.stores` entries gets the operator installed and an empty stores policy — no stores
+rendered, no harm done.
+
+### Supported providers
+
+The chart's accepted provider list is configured in `values.yaml` under
+`esoStores.validProviders` and currently covers:
+
+- `vault` (HashiCorp Vault)
+- `aws` (AWS Secrets Manager / Parameter Store)
+- `azurekv` (Azure Key Vault)
+- `gcpsm` (Google Cloud Secret Manager)
+- `kubernetes` (remote/local Kubernetes Secret store)
+
+Per-provider field schemas, auth methods, and minimal vs fully-fleshed examples are documented
+in `values.yaml` as commented YAML. Adding a new provider requires both updating
+`esoStores.validProviders` and confirming the rendering path passes through the user's
+`provider.<type>` block as-is (it does — there is no per-provider field-level logic).
+
+### Per-store cluster filtering
+
+Each store entry may carry a `clusterSelector` block evaluated at runtime against
+`.ManagedClusterLabels` on the receiving cluster. Both `matchLabels` and `matchExpressions`
+(operators `In`, `NotIn`, `Exists`, `DoesNotExist`) are supported. Entries whose selector does
+not match the current cluster are skipped silently. Entries with no `clusterSelector` always
+render.
+
+This lets a single clusterset-level config declare a store and restrict it to a subset of
+clusters in the set without splitting the config.
+
+### SecretStore vs ClusterSecretStore
+
+Each entry's `kind` field selects between namespaced `SecretStore` (per-namespace, lives in
+`namespace`) and cluster-scoped `ClusterSecretStore` (no `metadata.namespace`, optional
+`conditions[]` to restrict consuming namespaces). Default is `ClusterSecretStore`, configured
+under `esoStores.defaults.kind` in `values.yaml`.
+
+For `SecretStore` entries, the target namespace falls back to `esoStores.defaults.namespace`
+(default: `external-secrets-operator`) when the entry omits `.namespace`.
+
+For `ClusterSecretStore`, any `*SecretRef.namespace` and `caProvider.namespace` fields inside
+the provider block are required (the cluster store has no namespace to inherit from). The chart
+does not enforce this — ESO surfaces a runtime error if missing.
+
+### Validation
+
+Two layers, both sharing `esoStores.validProviders`:
+
+- **Chart-render time** (Helm): rejects inline default stores in `.Values.esoStores.stores` that
+  are missing `.name`, declare zero or multiple keys under `.provider`, or name a provider not
+  in `validProviders`. Failure aborts `helm template` with a descriptive error.
+- **Hub-template runtime** (per-cluster): re-runs the same checks against the live store list
+  pulled from rendered-config. Any malformed entry causes the entire stores policy to fail to
+  render on that cluster, surfacing as **whole-policy noncompliance** with the validation error
+  visible in policy status. Bad entries do not partially apply.
+
+### Example: clusterset config with two stores
+
+```yaml
+# In an autoshift clusterset values file
+config:
+  eso:
+    stores:
+      - name: vault-shared
+        kind: ClusterSecretStore
+        clusterSelector:
+          matchLabels:
+            tier: prod
+        conditions:
+          - namespaceSelector:
+              matchLabels:
+                eso-tier: shared
+        provider:
+          vault:
+            server: https://vault.corp.example.com:8200
+            path: kv
+            version: v2
+            auth:
+              kubernetes:
+                mountPath: kubernetes
+                role: shared-reader
+                serviceAccountRef:
+                  name: eso-vault-sa
+                  namespace: external-secrets-operator
+      - name: aws-team-a
+        kind: SecretStore
+        namespace: team-a
+        provider:
+          aws:
+            service: SecretsManager
+            region: us-east-1
+            auth:
+              jwt:
+                serviceAccountRef:
+                  name: team-a-irsa-sa
+```
+
+The first store deploys only to clusters labeled `tier: prod` and is consumable from any
+namespace labeled `eso-tier: shared`. The second deploys everywhere in the clusterset and is
+namespaced to `team-a`.
+
 ## Next Steps: Configuration
 
 ### 1. Explore Installed CRDs

--- a/policies/stable/external-secrets-operator/templates/policy-external-secrets-stores.yaml
+++ b/policies/stable/external-secrets-operator/templates/policy-external-secrets-stores.yaml
@@ -1,0 +1,404 @@
+{{- /*
+Renders ESO SecretStore / ClusterSecretStore resources from per-cluster rendered-config.
+
+Two validation layers:
+  - Chart-render time (this Helm block): validates inline default stores in
+    .Values.esoStores.stores. Fails the helm render if any entry is malformed.
+  - Hub-template runtime (object-templates-raw below): validates the live store list
+    pulled from each cluster's rendered-config ConfigMap. Calls `fail` on any malformed
+    entry, which surfaces as whole-policy noncompliance for the affected cluster.
+
+Both layers share the same valid-providers list, sourced from .Values.esoStores.validProviders.
+*/ -}}
+
+{{- /* ============================ Chart-time validation ============================ */ -}}
+{{- $validProviders := .Values.esoStores.validProviders | default (list) }}
+{{- $defaultKind := .Values.esoStores.defaults.kind | default "ClusterSecretStore" }}
+{{- $defaultNs := .Values.esoStores.defaults.namespace | default .Values.externalSecretsOperator.namespace }}
+{{- if not (or (eq $defaultKind "SecretStore") (eq $defaultKind "ClusterSecretStore")) }}
+{{-   fail (printf "esoStores.defaults.kind must be SecretStore or ClusterSecretStore, got %q" $defaultKind) }}
+{{- end }}
+{{- range $idx, $store := (.Values.esoStores.stores | default (list)) }}
+  {{- $name := $store.name | default "" }}
+  {{- if eq $name "" }}
+    {{- fail (printf "esoStores.stores[%d]: missing required field .name" $idx) }}
+  {{- end }}
+  {{- $kind := $store.kind | default $defaultKind }}
+  {{- if not (or (eq $kind "SecretStore") (eq $kind "ClusterSecretStore")) }}
+    {{- fail (printf "esoStores.stores[%s]: invalid kind %q (expected SecretStore|ClusterSecretStore)" $name $kind) }}
+  {{- end }}
+  {{- $provider := $store.provider | default (dict) }}
+  {{- if ne (len $provider) 1 }}
+    {{- fail (printf "esoStores.stores[%s]: must declare exactly one provider under .provider, got %d" $name (len $provider)) }}
+  {{- end }}
+  {{- $providerKey := "" }}
+  {{- range $pk, $_ := $provider }}
+    {{- if not (has $pk $validProviders) }}
+      {{- fail (printf "esoStores.stores[%s]: provider %q not in esoStores.validProviders %v" $name $pk $validProviders) }}
+    {{- end }}
+    {{- $providerKey = $pk }}
+  {{- end }}
+  {{- $providerCfg := index $provider $providerKey | default (dict) }}
+
+  {{- /* ###### VAULT VALIDATIONS ###### */ -}}
+  {{- if eq $providerKey "vault" }}
+    {{- if eq ($providerCfg.server | default "") "" }}
+      {{- fail (printf "esoStores.stores[%s].provider.vault: .server is required" $name) }}
+    {{- end }}
+    {{- $vAuth := $providerCfg.auth | default (dict) }}
+    {{- if ne (len $vAuth) 1 }}
+      {{- fail (printf "esoStores.stores[%s].provider.vault.auth: must declare exactly one auth method, got %d" $name (len $vAuth)) }}
+    {{- end }}
+    {{- $vaultAuthMethods := list "tokenSecretRef" "kubernetes" "appRole" "jwt" "cert" "ldap" "userPass" "iam" "gcp" }}
+    {{- range $ak, $_ := $vAuth }}
+      {{- if not (has $ak $vaultAuthMethods) }}
+        {{- fail (printf "esoStores.stores[%s].provider.vault.auth: unknown auth method %q (expected one of %v)" $name $ak $vaultAuthMethods) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* ###### AWS VALIDATIONS ###### */ -}}
+  {{- if eq $providerKey "aws" }}
+    {{- if eq ($providerCfg.region | default "") "" }}
+      {{- fail (printf "esoStores.stores[%s].provider.aws: .region is required" $name) }}
+    {{- end }}
+    {{- $awsService := $providerCfg.service | default "" }}
+    {{- if and (ne $awsService "SecretsManager") (ne $awsService "ParameterStore") }}
+      {{- fail (printf "esoStores.stores[%s].provider.aws: .service must be SecretsManager or ParameterStore, got %q" $name $awsService) }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* ###### AZUREKV VALIDATIONS ###### */ -}}
+  {{- if eq $providerKey "azurekv" }}
+    {{- if eq ($providerCfg.vaultUrl | default "") "" }}
+      {{- fail (printf "esoStores.stores[%s].provider.azurekv: .vaultUrl is required" $name) }}
+    {{- end }}
+    {{- $azAuthType := $providerCfg.authType | default "ServicePrincipal" }}
+    {{- if eq $azAuthType "ManagedIdentity" }}
+      {{- fail (printf "esoStores.stores[%s].provider.azurekv: authType ManagedIdentity is deprecated; use WorkloadIdentity" $name) }}
+    {{- end }}
+    {{- if eq $azAuthType "WorkloadIdentity" }}
+      {{- $azSa := $providerCfg.serviceAccountRef | default (dict) }}
+      {{- if eq ($azSa.name | default "") "" }}
+        {{- fail (printf "esoStores.stores[%s].provider.azurekv: authType WorkloadIdentity requires .serviceAccountRef.name" $name) }}
+      {{- end }}
+    {{- else if eq $azAuthType "ServicePrincipal" }}
+      {{- if eq ($providerCfg.tenantId | default "") "" }}
+        {{- fail (printf "esoStores.stores[%s].provider.azurekv: authType ServicePrincipal requires .tenantId" $name) }}
+      {{- end }}
+      {{- $azAsr := $providerCfg.authSecretRef | default (dict) }}
+      {{- $azCid := $azAsr.clientId | default (dict) }}
+      {{- if eq ($azCid.name | default "") "" }}
+        {{- fail (printf "esoStores.stores[%s].provider.azurekv: authType ServicePrincipal requires .authSecretRef.clientId.name" $name) }}
+      {{- end }}
+      {{- $hasSecret := hasKey $azAsr "clientSecret" }}
+      {{- $hasCert := hasKey $azAsr "clientCertificate" }}
+      {{- if and $hasSecret $hasCert }}
+        {{- fail (printf "esoStores.stores[%s].provider.azurekv: ServicePrincipal must use clientSecret OR clientCertificate, not both" $name) }}
+      {{- end }}
+      {{- if not (or $hasSecret $hasCert) }}
+        {{- fail (printf "esoStores.stores[%s].provider.azurekv: ServicePrincipal requires clientSecret or clientCertificate under .authSecretRef" $name) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* ###### GCPSM VALIDATIONS ###### */ -}}
+  {{- if eq $providerKey "gcpsm" }}
+    {{- if eq ($providerCfg.projectID | default "") "" }}
+      {{- fail (printf "esoStores.stores[%s].provider.gcpsm: .projectID is required (auto-detect only works on GKE)" $name) }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* ###### KUBERNETES VALIDATIONS ###### */ -}}
+  {{- if eq $providerKey "kubernetes" }}
+    {{- $kAuth := $providerCfg.auth | default (dict) }}
+    {{- $kAuthRef := $providerCfg.authRef | default (dict) }}
+    {{- $kHasAuth := gt (len $kAuth) 0 }}
+    {{- $kHasAuthRef := gt (len $kAuthRef) 0 }}
+    {{- if and $kHasAuth $kHasAuthRef }}
+      {{- fail (printf "esoStores.stores[%s].provider.kubernetes: must declare .auth OR .authRef, not both" $name) }}
+    {{- end }}
+    {{- if not (or $kHasAuth $kHasAuthRef) }}
+      {{- fail (printf "esoStores.stores[%s].provider.kubernetes: must declare .auth or .authRef" $name) }}
+    {{- end }}
+    {{- if $kHasAuth }}
+      {{- if ne (len $kAuth) 1 }}
+        {{- fail (printf "esoStores.stores[%s].provider.kubernetes.auth: must declare exactly one of {serviceAccount,token,cert}, got %d" $name (len $kAuth)) }}
+      {{- end }}
+      {{- $kAuthMethods := list "serviceAccount" "token" "cert" }}
+      {{- range $ak, $_ := $kAuth }}
+        {{- if not (has $ak $kAuthMethods) }}
+          {{- fail (printf "esoStores.stores[%s].provider.kubernetes.auth: unknown auth method %q (expected one of %v)" $name $ak $kAuthMethods) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- /* ================================ Policy body ================================ */ -}}
+{{- $policyName := "policy-external-secrets-stores" }}
+{{- $placementName := "placement-policy-external-secrets-stores" }}
+{{- $policyNamespace := $.Values.policy_namespace }}
+
+{{- /*
+Build a hub-template list literal of valid providers from .Values.esoStores.validProviders.
+Rendered once at chart time and embedded into the hub template so both layers stay in sync.
+*/ -}}
+{{- $validProvidersHubLit := "" }}
+{{- range $i, $p := $validProviders }}
+  {{- if eq $i 0 }}
+    {{- $validProvidersHubLit = printf "%q" $p }}
+  {{- else }}
+    {{- $validProvidersHubLit = printf "%s %q" $validProvidersHubLit $p }}
+  {{- end }}
+{{- end }}
+
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: {{ $policyName }}
+  namespace: {{ $policyNamespace }}
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+{{ if (($.Values.autoshift).dryRun) }}
+  remediationAction: inform
+{{ end }}
+  disabled: false
+  hubTemplateOptions:
+    serviceAccountName: autoshift-policy-service-account
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: external-secrets-stores
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates-raw: |
+            {{ "{{hub" }} $cm := (lookup "v1" "ConfigMap" "{{ $policyNamespace }}" (printf "%s.rendered-config" .ManagedClusterName)) | default dict {{ "hub}}" }}
+            {{ "{{hub" }} $config := (index $cm "data" | default dict) {{ "hub}}" }}
+            {{ "{{hub" }} $configYaml := (index $config "config" | default "" | fromYaml | default dict) {{ "hub}}" }}
+            {{ "{{hub" }} $eso := (index $configYaml "eso" | default dict) {{ "hub}}" }}
+            {{ "{{hub" }} $stores := (index $eso "stores" | default list) {{ "hub}}" }}
+            {{ "{{hub" }} $validProviders := list {{ $validProvidersHubLit }} {{ "hub}}" }}
+            {{ "{{hub" }} $defaultKind := "{{ $defaultKind }}" {{ "hub}}" }}
+            {{ "{{hub" }} $defaultNs := "{{ $defaultNs }}" {{ "hub}}" }}
+            {{- /* Validation pass: any malformed entry fails the whole policy render */ -}}
+            {{ "{{hub" }} range $idx, $store := $stores {{ "hub}}" }}
+              {{ "{{hub" }} $sName := index $store "name" | default "" {{ "hub}}" }}
+              {{ "{{hub" }} if eq $sName "" {{ "hub}}" }}
+                {{ "{{hub" }} fail (printf "esoStores: entry index %d missing required .name" $idx) {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} $sKind := index $store "kind" | default $defaultKind {{ "hub}}" }}
+              {{ "{{hub" }} if and (ne $sKind "SecretStore") (ne $sKind "ClusterSecretStore") {{ "hub}}" }}
+                {{ "{{hub" }} fail (printf "esoStores[%s]: invalid kind %q (expected SecretStore|ClusterSecretStore)" $sName $sKind) {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} $sProvider := index $store "provider" | default dict {{ "hub}}" }}
+              {{ "{{hub" }} if ne (len $sProvider) 1 {{ "hub}}" }}
+                {{ "{{hub" }} fail (printf "esoStores[%s]: must declare exactly one provider, got %d" $sName (len $sProvider)) {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} $sProviderKey := "" {{ "hub}}" }}
+              {{ "{{hub" }} range $pk, $_ := $sProvider {{ "hub}}" }}
+                {{ "{{hub" }} if not (has $pk $validProviders) {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s]: provider %q not in validProviders %v" $sName $pk $validProviders) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} $sProviderKey = $pk {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} $sProviderCfg := index $sProvider $sProviderKey | default dict {{ "hub}}" }}
+              {{- /* ###### VAULT VALIDATIONS ###### */ -}}
+              {{ "{{hub" }} if eq $sProviderKey "vault" {{ "hub}}" }}
+                {{ "{{hub" }} if eq (index $sProviderCfg "server" | default "") "" {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.vault: .server is required" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} $vAuth := index $sProviderCfg "auth" | default dict {{ "hub}}" }}
+                {{ "{{hub" }} if ne (len $vAuth) 1 {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.vault.auth: must declare exactly one auth method, got %d" $sName (len $vAuth)) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} $vaultAuthMethods := list "tokenSecretRef" "kubernetes" "appRole" "jwt" "cert" "ldap" "userPass" "iam" "gcp" {{ "hub}}" }}
+                {{ "{{hub" }} range $ak, $_ := $vAuth {{ "hub}}" }}
+                  {{ "{{hub" }} if not (has $ak $vaultAuthMethods) {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.vault.auth: unknown auth method %q (expected one of %v)" $sName $ak $vaultAuthMethods) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{- /* ###### AWS VALIDATIONS ###### */ -}}
+              {{ "{{hub" }} if eq $sProviderKey "aws" {{ "hub}}" }}
+                {{ "{{hub" }} if eq (index $sProviderCfg "region" | default "") "" {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.aws: .region is required" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} $awsService := index $sProviderCfg "service" | default "" {{ "hub}}" }}
+                {{ "{{hub" }} if and (ne $awsService "SecretsManager") (ne $awsService "ParameterStore") {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.aws: .service must be SecretsManager or ParameterStore, got %q" $sName $awsService) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{- /* ###### AZUREKV VALIDATIONS ###### */ -}}
+              {{ "{{hub" }} if eq $sProviderKey "azurekv" {{ "hub}}" }}
+                {{ "{{hub" }} if eq (index $sProviderCfg "vaultUrl" | default "") "" {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: .vaultUrl is required" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} $azAuthType := index $sProviderCfg "authType" | default "ServicePrincipal" {{ "hub}}" }}
+                {{ "{{hub" }} if eq $azAuthType "ManagedIdentity" {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: authType ManagedIdentity is deprecated; use WorkloadIdentity" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} if eq $azAuthType "WorkloadIdentity" {{ "hub}}" }}
+                  {{ "{{hub" }} $azSa := index $sProviderCfg "serviceAccountRef" | default dict {{ "hub}}" }}
+                  {{ "{{hub" }} if eq (index $azSa "name" | default "") "" {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: authType WorkloadIdentity requires .serviceAccountRef.name" $sName) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} else if eq $azAuthType "ServicePrincipal" {{ "hub}}" }}
+                  {{ "{{hub" }} if eq (index $sProviderCfg "tenantId" | default "") "" {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: authType ServicePrincipal requires .tenantId" $sName) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                  {{ "{{hub" }} $azAsr := index $sProviderCfg "authSecretRef" | default dict {{ "hub}}" }}
+                  {{ "{{hub" }} $azCid := index $azAsr "clientId" | default dict {{ "hub}}" }}
+                  {{ "{{hub" }} if eq (index $azCid "name" | default "") "" {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: authType ServicePrincipal requires .authSecretRef.clientId.name" $sName) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                  {{ "{{hub" }} $azHasSecret := hasKey $azAsr "clientSecret" {{ "hub}}" }}
+                  {{ "{{hub" }} $azHasCert := hasKey $azAsr "clientCertificate" {{ "hub}}" }}
+                  {{ "{{hub" }} if and $azHasSecret $azHasCert {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: ServicePrincipal must use clientSecret OR clientCertificate, not both" $sName) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                  {{ "{{hub" }} if not (or $azHasSecret $azHasCert) {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.azurekv: ServicePrincipal requires clientSecret or clientCertificate under .authSecretRef" $sName) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{- /* ###### GCPSM VALIDATIONS ###### */ -}}
+              {{ "{{hub" }} if eq $sProviderKey "gcpsm" {{ "hub}}" }}
+                {{ "{{hub" }} if eq (index $sProviderCfg "projectID" | default "") "" {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.gcpsm: .projectID is required (auto-detect only works on GKE)" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{- /* ###### KUBERNETES VALIDATIONS ###### */ -}}
+              {{ "{{hub" }} if eq $sProviderKey "kubernetes" {{ "hub}}" }}
+                {{ "{{hub" }} $kAuth := index $sProviderCfg "auth" | default dict {{ "hub}}" }}
+                {{ "{{hub" }} $kAuthRef := index $sProviderCfg "authRef" | default dict {{ "hub}}" }}
+                {{ "{{hub" }} $kHasAuth := gt (len $kAuth) 0 {{ "hub}}" }}
+                {{ "{{hub" }} $kHasAuthRef := gt (len $kAuthRef) 0 {{ "hub}}" }}
+                {{ "{{hub" }} if and $kHasAuth $kHasAuthRef {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.kubernetes: must declare .auth OR .authRef, not both" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} if not (or $kHasAuth $kHasAuthRef) {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s].provider.kubernetes: must declare .auth or .authRef" $sName) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} if $kHasAuth {{ "hub}}" }}
+                  {{ "{{hub" }} if ne (len $kAuth) 1 {{ "hub}}" }}
+                    {{ "{{hub" }} fail (printf "esoStores[%s].provider.kubernetes.auth: must declare exactly one of {serviceAccount,token,cert}, got %d" $sName (len $kAuth)) {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                  {{ "{{hub" }} $kAuthMethods := list "serviceAccount" "token" "cert" {{ "hub}}" }}
+                  {{ "{{hub" }} range $ak, $_ := $kAuth {{ "hub}}" }}
+                    {{ "{{hub" }} if not (has $ak $kAuthMethods) {{ "hub}}" }}
+                      {{ "{{hub" }} fail (printf "esoStores[%s].provider.kubernetes.auth: unknown auth method %q (expected one of %v)" $sName $ak $kAuthMethods) {{ "hub}}" }}
+                    {{ "{{hub" }} end {{ "hub}}" }}
+                  {{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+            {{ "{{hub" }} end {{ "hub}}" }}
+            {{- /* Render pass: emit a musthave entry for each store whose clusterSelector matches */ -}}
+            {{ "{{hub" }} range $idx, $store := $stores {{ "hub}}" }}
+              {{ "{{hub" }} $sName := index $store "name" {{ "hub}}" }}
+              {{ "{{hub" }} $sKind := index $store "kind" | default $defaultKind {{ "hub}}" }}
+              {{ "{{hub" }} $sNs := index $store "namespace" | default $defaultNs {{ "hub}}" }}
+              {{- /* Evaluate clusterSelector against .ManagedClusterLabels */ -}}
+              {{ "{{hub" }} $state := dict "matches" true {{ "hub}}" }}
+              {{ "{{hub" }} $sel := index $store "clusterSelector" | default dict {{ "hub}}" }}
+              {{ "{{hub" }} range $lk, $lv := (index $sel "matchLabels" | default dict) {{ "hub}}" }}
+                {{ "{{hub" }} if ne (index $.ManagedClusterLabels $lk | default "") $lv {{ "hub}}" }}
+                  {{ "{{hub" }} $_ := set $state "matches" false {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} range $_, $expr := (index $sel "matchExpressions" | default list) {{ "hub}}" }}
+                {{ "{{hub" }} $eKey := index $expr "key" {{ "hub}}" }}
+                {{ "{{hub" }} $eOp := index $expr "operator" {{ "hub}}" }}
+                {{ "{{hub" }} $eVals := index $expr "values" | default list {{ "hub}}" }}
+                {{ "{{hub" }} $cVal := index $.ManagedClusterLabels $eKey | default "" {{ "hub}}" }}
+                {{ "{{hub" }} $cHas := hasKey $.ManagedClusterLabels $eKey {{ "hub}}" }}
+                {{ "{{hub" }} if eq $eOp "In" {{ "hub}}" }}
+                  {{ "{{hub" }} if not (has $cVal $eVals) {{ "hub}}" }}{{ "{{hub" }} $_ := set $state "matches" false {{ "hub}}" }}{{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} else if eq $eOp "NotIn" {{ "hub}}" }}
+                  {{ "{{hub" }} if has $cVal $eVals {{ "hub}}" }}{{ "{{hub" }} $_ := set $state "matches" false {{ "hub}}" }}{{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} else if eq $eOp "Exists" {{ "hub}}" }}
+                  {{ "{{hub" }} if not $cHas {{ "hub}}" }}{{ "{{hub" }} $_ := set $state "matches" false {{ "hub}}" }}{{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} else if eq $eOp "DoesNotExist" {{ "hub}}" }}
+                  {{ "{{hub" }} if $cHas {{ "hub}}" }}{{ "{{hub" }} $_ := set $state "matches" false {{ "hub}}" }}{{ "{{hub" }} end {{ "hub}}" }}
+                {{ "{{hub" }} else {{ "hub}}" }}
+                  {{ "{{hub" }} fail (printf "esoStores[%s]: matchExpression has unknown operator %q" $sName $eOp) {{ "hub}}" }}
+                {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+              {{ "{{hub" }} if $state.matches {{ "hub}}" }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: external-secrets.io/v1
+                kind: {{ "{{hub" }} $sKind {{ "hub}}" }}
+                metadata:
+                  name: {{ "{{hub" }} $sName {{ "hub}}" }}
+                  {{ "{{hub-" }} if eq $sKind "SecretStore" {{ "hub}}" }}
+                  namespace: {{ "{{hub" }} $sNs {{ "hub}}" }}
+                  {{ "{{hub-" }} end {{ "hub}}" }}
+                spec:
+                  {{ "{{hub-" }} $sController := index $store "controller" | default "" {{ "hub}}" }}
+                  {{ "{{hub-" }} if ne $sController "" {{ "hub}}" }}
+                  controller: {{ "{{hub" }} $sController {{ "hub}}" }}
+                  {{ "{{hub-" }} end {{ "hub}}" }}
+                  {{ "{{hub-" }} $sRefresh := index $store "refreshInterval" | default 0 | toInt {{ "hub}}" }}
+                  {{ "{{hub-" }} if gt $sRefresh 0 {{ "hub}}" }}
+                  refreshInterval: {{ "{{hub" }} $sRefresh {{ "hub}}" }}
+                  {{ "{{hub-" }} end {{ "hub}}" }}
+                  {{ "{{hub-" }} $sConditions := index $store "conditions" | default list {{ "hub}}" }}
+                  {{ "{{hub-" }} if and (eq $sKind "ClusterSecretStore") (gt (len $sConditions) 0) {{ "hub}}" }}
+                  conditions:
+                    {{ "{{hub" }} $sConditions | toYaml | autoindent {{ "hub}}" }}
+                  {{ "{{hub-" }} end {{ "hub}}" }}
+                  provider:
+                    {{ "{{hub" }} index $store "provider" | toYaml | autoindent {{ "hub}}" }}
+              {{ "{{hub" }} end {{ "hub}}" }}
+            {{ "{{hub" }} end {{ "hub}}" }}
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: {{ $placementName }}
+  namespace: {{ $policyNamespace }}
+spec:
+  clusterSets:
+  {{- range $clusterSet, $value := $.Values.hubClusterSets }}
+    - {{ $clusterSet }}
+  {{- end }}
+  {{- range $clusterSet, $value := $.Values.managedClusterSets }}
+    - {{ $clusterSet }}
+  {{- end }}
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/external-secrets-operator'
+              operator: In
+              values:
+              - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: {{ $placementName }}
+  namespace: {{ $policyNamespace }}
+placementRef:
+  name: {{ $placementName }}
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: {{ $policyName }}
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/policies/stable/external-secrets-operator/templates/policy-external-secrets-stores.yaml
+++ b/policies/stable/external-secrets-operator/templates/policy-external-secrets-stores.yaml
@@ -182,6 +182,7 @@ spec:
             compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
             noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
           object-templates-raw: |
+            #Indentation Anchor
             {{ "{{hub" }} $cm := (lookup "v1" "ConfigMap" "{{ $policyNamespace }}" (printf "%s.rendered-config" .ManagedClusterName)) | default dict {{ "hub}}" }}
             {{ "{{hub" }} $config := (index $cm "data" | default dict) {{ "hub}}" }}
             {{ "{{hub" }} $configYaml := (index $config "config" | default "" | fromYaml | default dict) {{ "hub}}" }}
@@ -355,10 +356,10 @@ spec:
                   {{ "{{hub-" }} $sConditions := index $store "conditions" | default list {{ "hub}}" }}
                   {{ "{{hub-" }} if and (eq $sKind "ClusterSecretStore") (gt (len $sConditions) 0) {{ "hub}}" }}
                   conditions:
-                    {{ "{{hub" }} $sConditions | toYaml | autoindent {{ "hub}}" }}
+                        {{ "{{hub" }} $sConditions | toYaml | autoindent {{ "hub}}" }}
                   {{ "{{hub-" }} end {{ "hub}}" }}
                   provider:
-                    {{ "{{hub" }} index $store "provider" | toYaml | autoindent {{ "hub}}" }}
+                        {{ "{{hub" }} index $store "provider" | toYaml | autoindent {{ "hub}}" }}
               {{ "{{hub" }} end {{ "hub}}" }}
             {{ "{{hub" }} end {{ "hub}}" }}
 ---

--- a/policies/stable/external-secrets-operator/values.yaml
+++ b/policies/stable/external-secrets-operator/values.yaml
@@ -11,7 +11,32 @@ externalSecretsOperator:
   operatorGroupName: external-secrets-operator-operator-group
   # targetNamespaces: # Optional: specify target namespaces for namespace-scoped operators
   #   - external-secrets-operator
-  
+
+# SecretStore / ClusterSecretStore rendering. Real per-cluster store config lives in
+# rendered-config ConfigMaps under `config.eso.stores` and is read at runtime by the
+# stores policy template via hub-template lookup. Inline entries under .stores below
+# are validated at chart-render time and are intended only for tests / static defaults.
+esoStores:
+  # validProviders gates which provider keys are accepted, in BOTH layers:
+  #   - chart-render time: helm fails if any inline default store names a provider not listed here
+  #   - hub-template runtime: the policy fails to render (whole-policy noncompliant) if any
+  #     rendered-config store names a provider not listed here
+  # Adding a provider here also requires adding rendering support in
+  # templates/policy-external-secrets-stores.yaml.
+  validProviders:
+    - vault
+    - aws
+    - azurekv
+    - gcpsm
+    - kubernetes
+  defaults:
+    # kind used when a store entry omits .kind
+    kind: ClusterSecretStore        # SecretStore | ClusterSecretStore
+    # namespace used for kind=SecretStore entries that omit .namespace
+    namespace: external-secrets-operator
+  # Inline stores. Leave empty in the typical case — real config flows from rendered-config.
+  stores: []
+
 # hubClusterSets:
 #   hub:
 #     labels:
@@ -26,6 +51,7 @@ externalSecretsOperator:
 #
 # Enable/Disable:
 # external-secrets-operator<bool>: 'true' or 'false' - Controls whether external-secrets-operator is managed
+#   (also gates rendering of SecretStore / ClusterSecretStore resources from rendered-config)
 #
 # Configuration:
 # external-secrets-operator-subscription-name<string>: Operator subscription name (default: 'openshift-external-secrets-operator')
@@ -41,3 +67,131 @@ externalSecretsOperator:
 # autoshift.io/external-secrets-operator-version: 'operator-name.v1.x.x'
 # autoshift.io/external-secrets-operator-source: 'redhat-operators'
 # autoshift.io/external-secrets-operator-source-namespace: 'openshift-marketplace'
+
+### SecretStore / ClusterSecretStore configuration reference
+#
+# Real config lives in cluster/clusterset values files under config.eso.stores and flows
+# through the rendered-config ConfigMap. The stores policy reads each cluster's
+# rendered-config at runtime, validates each entry, applies the per-store clusterSelector
+# filter, and renders the matching resources.
+#
+# Whole-policy failure semantics: any invalid entry (bad provider, multiple providers,
+# missing identity) causes the entire stores policy to surface as noncompliant on that
+# cluster. Bad entries do not partially apply.
+#
+# config:
+#   eso:
+#     stores:
+#       - name: vault-shared
+#         kind: ClusterSecretStore     # SecretStore | ClusterSecretStore (default from esoStores.defaults.kind)
+#         namespace: my-app            # used only when kind=SecretStore (default from esoStores.defaults.namespace)
+#         clusterSelector:             # optional per-store filter on .ManagedClusterLabels
+#           matchLabels:
+#             tier: prod
+#           matchExpressions:
+#             - { key: env, operator: In, values: [prod, stage] }
+#         conditions:                  # CSS only — restricts which namespaces may consume the store
+#           - namespaces: [team-a, team-b]
+#           - namespaceRegexes: ['^prod-.*$']
+#           - namespaceSelector:
+#               matchLabels: { eso-tier: shared }
+#         refreshInterval: 300         # seconds; 0/empty = controller default
+#         controller: ''               # empty = default controller
+#         provider:
+#           # exactly one of vault | aws | azurekv | gcpsm | kubernetes (must be in esoStores.validProviders)
+#
+#           vault:
+#             server: https://vault.example.com:8200
+#             path: secret
+#             version: v2              # v1 | v2
+#             namespace: ''            # Vault Enterprise namespace (NOT a k8s namespace)
+#             caBundle: ''             # base64 PEM (use either caBundle OR caProvider, not both)
+#             caProvider:
+#               type: ConfigMap        # ConfigMap | Secret
+#               name: vault-ca
+#               key: ca.crt
+#               namespace: external-secrets   # CSS only
+#             auth:
+#               # exactly one of: tokenSecretRef | kubernetes | appRole | jwt | cert | ldap | userPass | iam | gcp
+#               kubernetes:
+#                 mountPath: kubernetes
+#                 role: app-role
+#                 serviceAccountRef:
+#                   name: app-sa
+#                   namespace: external-secrets   # CSS only
+#                   audiences: [vault]
+#               # tokenSecretRef: { name, key, namespace }
+#               # appRole:
+#               #   path: approle
+#               #   roleId: <id>
+#               #   secretRef: { name, key, namespace }
+#
+#           # aws:
+#           #   service: SecretsManager        # SecretsManager | ParameterStore
+#           #   region: us-east-1
+#           #   role: arn:aws:iam::...:role/eso         # optional sts:AssumeRole target
+#           #   prefix: ''                              # optional key prefix
+#           #   auth:
+#           #     # one of: jwt (IRSA/Pod Identity, preferred) | secretRef (static creds) | omitted (SDK chain)
+#           #     jwt:
+#           #       serviceAccountRef:
+#           #         name: app-irsa-sa
+#           #         namespace: external-secrets       # CSS only
+#           #         audiences: ['sts.amazonaws.com']
+#           #     # secretRef:
+#           #     #   accessKeyIDSecretRef:     { name, key, namespace }
+#           #     #   secretAccessKeySecretRef: { name, key, namespace }
+#           #     #   sessionTokenSecretRef:    { name, key, namespace }
+#
+#           # azurekv:
+#           #   vaultUrl: https://my-kv.vault.azure.net
+#           #   authType: WorkloadIdentity     # WorkloadIdentity (preferred) | ServicePrincipal | ManagedIdentity (deprecated)
+#           #   tenantId: ''
+#           #   environmentType: PublicCloud   # PublicCloud | USGovernmentCloud | ChinaCloud | GermanCloud | AzureStackCloud
+#           #   identityId: ''                 # niche: pick one MI when multiple are assigned
+#           #   serviceAccountRef:             # required for WorkloadIdentity
+#           #     name: app-wi-sa
+#           #     namespace: external-secrets  # CSS only
+#           #   authSecretRef:                 # required for ServicePrincipal
+#           #     clientId:          { name, key, namespace }
+#           #     clientSecret:      { name, key, namespace }
+#           #     clientCertificate: { name, key, namespace }
+#           #     tenantId:          { name, key, namespace }
+#
+#           # gcpsm:
+#           #   projectID: my-gcp-project
+#           #   location: ''                   # required for CMEK / regional secrets
+#           #   secretVersionSelectionPolicy: LatestOrFail   # LatestOrFail | LatestOrFetch
+#           #   auth:
+#           #     # one of: workloadIdentity (GKE) | secretRef (off-cluster SA key) | omitted (ADC)
+#           #     workloadIdentity:
+#           #       clusterLocation: ''
+#           #       clusterName: ''
+#           #       clusterProjectID: ''
+#           #       serviceAccountRef:
+#           #         name: app-wi-sa
+#           #         namespace: external-secrets    # CSS only
+#           #     # secretRef:
+#           #     #   secretAccessKeySecretRef: { name, key, namespace }   # GCP SA JSON key
+#
+#           # kubernetes:
+#           #   remoteNamespace: shared-secrets
+#           #   server:
+#           #     url: ''                          # default kubernetes.default
+#           #     caBundle: ''                     # XOR caProvider
+#           #     caProvider:
+#           #       type: ConfigMap                # ConfigMap | Secret
+#           #       name: kube-root-ca.crt
+#           #       key: ca.crt
+#           #       namespace: ''                  # CSS only
+#           #   auth:
+#           #     # exactly one of: serviceAccount | token | cert
+#           #     serviceAccount:
+#           #       name: eso-reader
+#           #       namespace: external-secrets    # CSS only
+#           #       audiences: []
+#           #     # token:
+#           #     #   bearerToken: { name, key, namespace }
+#           #     # cert:
+#           #     #   clientCert: { name, key, namespace }
+#           #     #   clientKey:  { name, key, namespace }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] New policy (new operator or cluster configuration)
- [ ] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [ ] Other: <!-- describe -->

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
