### PR TITLE
updating cluster config maps with support for rendering config maps for

### DIFF
--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -140,8 +140,10 @@ spec:
               values:
               - 'true'
 {{- end }}
+{{- $allHubSets := append ($.Values.hubClusterSets | default list) ($.Values.selfManagedHubSet | default dict) }}
+{{- if not (empty $allHubSets }}
   clusterSets:
-    {{- range $clusterSet, $value := $.Values.hubClusterSets  }}
+    {{- range $clusterSet, $value := $allHubSets  }}
     - {{ $clusterSet }}
     {{- end }}
   tolerations:
@@ -149,6 +151,7 @@ spec:
       operator: Exists
     - key: cluster.open-cluster-management.io/unavailable
       operator: Exists
+{{- end }}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -91,6 +91,7 @@ spec:
                 {{ "{{-" }} $allRendered = $wrapper {{ "}}" }}
               {{ "{{-" }} end {{ "}}" }}
             {{ "{{-" }} end {{ "}}" }}
+            {{ if $.Values.debug | default false }}
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
@@ -103,6 +104,7 @@ spec:
                 data:
                   allRendered: |
                     {{ "{{" }} $allRendered | toYaml | autoindent {{ "}}" }}
+            {{ end }}
 
             {{ "{{-" }} range $ns, $clusters := ($allRendered | default dict) {{ "}}" }}
               {{ "{{-" }} range $clusterName, $config := $clusters {{ "}}" }}

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -141,10 +141,8 @@ spec:
               values:
               - 'true'
 {{- end }}
-{{- $allHubSets := append ($.Values.hubClusterSets | default list) ($.Values.selfManagedHubSet | default dict) }}
-{{- if not (empty $allHubSets }}
   clusterSets:
-    {{- range $clusterSet, $value := $allHubSets  }}
+    {{- range $clusterSet, $value := $.Values.hubClusterSets  }}
     - {{ $clusterSet }}
     {{- end }}
   tolerations:
@@ -152,7 +150,6 @@ spec:
       operator: Exists
     - key: cluster.open-cluster-management.io/unavailable
       operator: Exists
-{{- end }}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -1,8 +1,7 @@
-
-{{- $policyNamespace := $.Values.policy_namespace }}
-{{- $policyName := "policy-cluster-configs" }}
-{{- $placementName := "placement-cluster-configs" }}
-{{- $configPolicyName := "policy-cluster-configs" }}
+  {{- $policyNamespace := $.Values.policy_namespace }}
+  {{- $policyName := "policy-cluster-configs" }}
+  {{- $placementName := "placement-cluster-configs" }}
+  {{- $configPolicyName := "policy-cluster-configs" }}
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -28,64 +27,99 @@ spec:
           remediationAction: enforce
           severity: high
           object-templates-raw: |
-            {{ "{{" }} $policyNamespace := "{{ "{{hub" }} (index .ManagedClusterLabels "{{ $.Values.autoshiftLabelPrefix | default "autoshift.io/" }}policy-namespace") | default "{{ $policyNamespace }}" {{ "hub}}" }}" {{ "}}" }}
+            #Indentation Anchor
             {{ "{{" }} $allRendered := dict {{ "}}" }}
-            {{- /* Build a map of ManagedCluster name -> clusterset label for lookup */ -}}
-            {{ "{{" }} $mcClusterSets := dict {{ "}}" }}
-            {{ "{{" }} $managedClusterLookupResult := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "") | default dict {{ "}}" }}
-            {{ "{{" }} range $_, $cluster := ((index $managedClusterLookupResult "items") | default list) {{ "}}" }}
-              {{ "{{" }} $clusterName := (index $cluster "metadata" "name") {{ "}}" }}
-              {{ "{{" }} $clusterSet := (index $cluster.metadata.labels "cluster.open-cluster-management.io/clusterset") | default "" {{ "}}" }}
-              {{ "{{" }} $_ := set $mcClusterSets $clusterName $clusterSet {{ "}}" }}
+            {{ "{{-" }} $managedClusterLookupResult := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "") | default dict {{ "}}" }}
+            {{ "{{-" }} $allClusterConfigs := (dict) {{ "}}" }}
+            {{ "{{-" }} $allClusterSetConfigs := (dict) {{ "}}" }}
+            {{ "{{-" }} $clusterConfigMaps := (lookup "v1" "ConfigMap" "" "" "autoshift.io/cluster-configs") | default dict {{ "}}" }}
+            {{ "{{-" }} $clusterSetConfigMaps := (lookup "v1" "ConfigMap" "" "" "autoshift.io/cluster-set-configs") | default dict {{ "}}" }}
+            {{ "{{-" }} $defaultConfigs := (dict) {{ "}}" }}
+            {{ "{{-" }} $defaultConfigMaps := (lookup "v1" "ConfigMap" "" "" "autoshift.io/cluster-default-configs") | default dict {{ "}}" }}
+            ##### DEFAULT CONFIG MAPS #####
+            {{ "{{-" }} range $idx, $cm := $defaultConfigMaps.items {{ "}}" }}
+                {{ "{{-" }} $_ := set $defaultConfigs $cm.metadata.namespace ((($cm).data).config | default "{}" | fromJson) {{ "}}" }}
             {{ "{{-" }} end {{ "}}" }}
-            {{- /* Pre-fetch all clusterset ConfigMaps into a dict (avoids per-cluster lookups) */ -}}
-            {{ "{{" }} $allClusterSetConfigs := dict {{ "}}" }}
-            {{ "{{" }} $allClusterSetConfigMaps := (lookup "v1" "ConfigMap" $policyNamespace "" "autoshift.io/cluster-set-configs") | default dict {{ "}}" }}
-            {{ "{{" }} range $_, $csCm := ($allClusterSetConfigMaps.items | default list) {{ "}}" }}
-              {{ "{{" }} $csName := (replace "cluster-set-config." "" $csCm.metadata.name) {{ "}}" }}
-              {{ "{{" }} $_ := set $allClusterSetConfigs $csName ($csCm.data.config | default "{}" | fromJson) {{ "}}" }}
-            {{ "{{-" }} end {{ "}}" }}
-            {{- /* Loop over all cluster ConfigMaps — resolve clusterset and merge */ -}}
-            {{ "{{" }} $allClusterConfigMaps := (lookup "v1" "ConfigMap" $policyNamespace "" "autoshift.io/cluster-configs") | default dict {{ "}}" }}
-            {{ "{{" }} range $_, $cm := ($allClusterConfigMaps.items | default list) {{ "}}" }}
-              {{ "{{" }} $cmName := $cm.metadata.name {{ "}}" }}
-              {{ "{{" }} if (hasPrefix "managed-cluster-config." $cmName) {{ "}}" }}
-                {{ "{{" }} $clusterName := (replace "managed-cluster-config." "" $cmName) {{ "}}" }}
-                {{ "{{" }} $clusterConfig := ($cm.data.config | default "{}" | fromJson) {{ "}}" }}
-                {{- /* Resolve clusterset: config.clusterSet > ManagedCluster label > "default" */ -}}
-                {{ "{{" }} $clusterSetName := (index $clusterConfig "clusterSet" | default "") {{ "}}" }}
-                {{ "{{" }} if (empty $clusterSetName) {{ "}}" }}
-                  {{ "{{" }} $clusterSetName = (index $mcClusterSets $clusterName | default "default") {{ "}}" }}
-                {{ "{{-" }} else {{ "}}" }}
-                  {{ "{{" }} $clusterSetName = (printf "%s{{ $.Values.clusterSetSuffix | default "" }}" $clusterSetName) {{ "}}" }}
+            ##### CLUSTER SET CONFIG MAPS #####
+            {{ "{{-" }} $seenClusterSetConfigs := (dict) {{ "}}" }}
+            {{ "{{-" }} range $_, $clusterSetConfigMap := $clusterSetConfigMaps.items {{ "}}" }}
+              {{ "{{-" }} $cm := $clusterSetConfigMap {{ "}}" }}
+              {{ "{{-" }} if hasPrefix "cluster-set-config." $cm.metadata.name {{ "}}" }}
+                {{ "{{-" }}  $clusterSetName := ($cm.metadata.name | replace "cluster-set-config." "")  {{ "}}" }}
+                {{ "{{-" }} if (hasKey $seenClusterSetConfigs $clusterSetName) {{ "}}" }}
+                  {{ "{{-" }} fail (printf "Duplicate cluster set config detected: ManagedClusterSet %s has multiple config maps!. ManagedClusterSet config maps must be unique across all namespaces!" ($cm.metadata.name | replace "cluster-set-config." "")) {{ "}}" }}
                 {{ "{{-" }} end {{ "}}" }}
-                {{ "{{" }} $clusterSetConfig := (index $allClusterSetConfigs $clusterSetName | default dict) {{ "}}" }}
-                {{ "{{" }} $renderedConfig := (dict) {{ "}}" }}
-                {{ "{{" }} $_ := (merge $renderedConfig $clusterConfig $clusterSetConfig) {{ "}}" }}
-                {{ "{{" }} $_ := set $allRendered $clusterName $renderedConfig {{ "}}" }}
+                {{ "{{-" }} $_ := set $seenClusterSetConfigs $clusterSetName $cm.metadata.namespace {{ "}}" }}
+                {{ "{{-" }} $clusterSetName := ($cm.metadata.name | replace "cluster-set-config." "") {{ "}}" }}
+                {{ "{{-" }} if not (hasKey $allClusterSetConfigs $cm.metadata.namespace) {{ "}}" }}
+                  {{ "{{-" }} $_ := set $allClusterSetConfigs $cm.metadata.namespace (dict) {{ "}}" }}
+                {{ "{{-" }} end {{ "}}" }}
+                {{ "{{-" }} $clusterSetConfig := (index $clusterSetConfigMap.data "config" | default "{}" | fromJson) {{ "}}" }}
+                {{ "{{-" }} $_ := set (index $allClusterSetConfigs $cm.metadata.namespace) $clusterSetName $clusterSetConfig{{ "}}" }}
               {{ "{{-" }} end {{ "}}" }}
             {{ "{{-" }} end {{ "}}" }}
-            {{- /* ManagedClusters without a cluster ConfigMap — render with clusterset defaults only */ -}}
-            {{ "{{" }} range $clusterName, $clusterSet := $mcClusterSets {{ "}}" }}
-              {{ "{{" }} if not (hasKey $allRendered $clusterName) {{ "}}" }}
-                {{ "{{" }} $_ := set $allRendered $clusterName (index $allClusterSetConfigs $clusterSet | default dict) {{ "}}" }}
+            ##### CLUSTER CONFIG MAPS ####
+            {{ "{{-" }} range $_, $clusterConfigMap := ($clusterConfigMaps.items | default list) {{ "}}" }}
+              {{ "{{-" }} if hasPrefix "managed-cluster-config." $clusterConfigMap.metadata.name {{ "}}" }}
+                {{ "{{-" }} $clusterConfig := (index $clusterConfigMap.data "config" | default "{}" | fromJson) {{ "}}" }}
+                {{ "{{-" }} $clusterNs := $clusterConfigMap.metadata.namespace {{ "}}" }}
+                {{ "{{-" }} $clusterName := ($clusterConfigMap.metadata.name | replace "managed-cluster-config." "") {{ "}}" }}
+                {{ "{{-" }} $wrapper := (dict $clusterNs (dict $clusterName $clusterConfig)) {{ "}}" }}
+                {{ "{{-" }} $allClusterConfigs = merge $wrapper $allClusterConfigs {{ "}}" }}
+                {{ "{{-" }} $clusterSetName := ($clusterConfig.clusterSet | default "") {{ "}}" }}
+                {{ "{{-" }} $clusterSetConfig := (dig $clusterNs $clusterSetName (dict) $allClusterSetConfigs )  {{ "}}" }}
+                {{ "{{-" }} $defaultConfig := (index $defaultConfigs $clusterNs | default dict)  {{ "}}" }}
+                {{ "{{-" }} $renderedConfig := (dict) {{ "}}" }}
+                {{ "{{-" }} $_ := merge $renderedConfig $clusterConfig $clusterSetConfig $defaultConfig   {{ "}}" }}
+                {{ "{{-" }} if not (hasKey $allRendered $clusterNs) {{ "}}" }}
+                  {{ "{{-" }} $_ := set $allRendered $clusterNs (dict) {{ "}}" }}
+                {{ "{{-" }} end {{ "}}" }}
+                {{ "{{-" }} $_ := set (index $allRendered $clusterNs) $clusterName $renderedConfig {{ "}}" }}
               {{ "{{-" }} end {{ "}}" }}
             {{ "{{-" }} end {{ "}}" }}
-            {{- /* Single output loop */ -}}
-            {{ "{{" }} range $clusterName, $renderedConfig := $allRendered {{ "}}" }}
+            {{ "{{-" }} range $_, $cluster := $managedClusterLookupResult.items {{ "}}" }}
+              {{ "{{-" }} $clusterSetName := index ((($cluster).metadata).labels | default dict) "cluster.open-cluster-management.io/clusterset" | default ""  {{ "}}" }}
+              {{ "{{-" }} $clusterSetNamespace  := (index $seenClusterSetConfigs $clusterSetName | default "")  {{ "}}" }}
+              {{ "{{-" }} $clusterSetConfig := (dig $clusterSetNamespace $clusterSetName (dict) $allClusterSetConfigs) {{ "}}" }}
+              {{ "{{-" }} $defaultConfig := (index $defaultConfigs $clusterSetNamespace | default dict) {{ "}}" }}
+              {{ "{{-" }} if ne $clusterSetNamespace "" {{ "}}" }}
+                {{ "{{-" }} $clusterConfig := (dig $clusterSetNamespace $cluster.metadata.name (dict) $allClusterConfigs) {{ "}}" }}
+                {{ "{{-" }} $renderedConfig := (dict) {{ "}}" }}
+                {{ "{{-" }} $_ := merge $renderedConfig $clusterConfig $clusterSetConfig $defaultConfig {{ "}}" }}
+                {{ "{{-" }} $wrapper := (dict $clusterSetNamespace (dict $cluster.metadata.name $renderedConfig)) {{ "}}" }}
+                {{ "{{-" }} $_ := merge $wrapper $allRendered {{ "}}" }}
+                {{ "{{-" }} $allRendered = $wrapper {{ "}}" }}
+              {{ "{{-" }} end {{ "}}" }}
+            {{ "{{-" }} end {{ "}}" }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: cluster-config-debug
+                  namespace: {{ $.Values.policy_namespace }}
+                  labels:
+                    autoshift.io/debug: ""
+                data:
+                  allRendered: |
+                    {{ "{{" }} $allRendered | toYaml | autoindent {{ "}}" }}
+
+            {{ "{{-" }} range $ns, $clusters := ($allRendered | default dict) {{ "}}" }}
+              {{ "{{-" }} range $clusterName, $config := $clusters {{ "}}" }}
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
                 kind: ConfigMap
                 metadata:
                   name: {{ "{{" }} (printf "%s.%s" $clusterName "rendered-config") {{ "}}" }}
-                  namespace: {{ "{{" }} $policyNamespace {{ "}}" }}
+                  namespace: {{ "{{" }} $ns {{ "}}" }}
                   labels:
                     autoshift.io/rendered-config-map: ""
                 data:
                   config: |
-                    {{ "{{" }} $renderedConfig | toYaml | autoindent {{ "}}" }}
-            {{ "{{-" }} end {{ "}}" }}
+                    {{ "{{" }} $config | toYaml | autoindent {{ "}}" }}
+              {{ "{{" }} end {{ "}}" }}
+            {{ "{{" }} end {{ "}}" }}
 
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1
@@ -94,6 +128,16 @@ metadata:
   name: {{ $placementName }}
   namespace: {{ $policyNamespace }}
 spec:
+{{- if (empty $.Values.hubClusterSets) }}
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/noop-placement'
+              operator: In
+              values:
+              - 'true'
+{{- end }}
   clusterSets:
     {{- range $clusterSet, $value := $.Values.hubClusterSets  }}
     - {{ $clusterSet }}

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -131,16 +131,6 @@ metadata:
   name: {{ $placementName }}
   namespace: {{ $policyNamespace }}
 spec:
-{{- if (empty $.Values.hubClusterSets) }}
-  predicates:
-    - requiredClusterSelector:
-        labelSelector:
-          matchExpressions:
-            - key: 'autoshift.io/noop-placement'
-              operator: In
-              values:
-              - 'true'
-{{- end }}
   clusterSets:
     {{- range $clusterSet, $value := $.Values.hubClusterSets  }}
     - {{ $clusterSet }}

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -1,3 +1,4 @@
+{{- if not (empty $.Values.hubClusterSets) }}
   {{- $policyNamespace := $.Values.policy_namespace }}
   {{- $policyName := "policy-cluster-configs" }}
   {{- $placementName := "placement-cluster-configs" }}
@@ -166,3 +167,4 @@ subjects:
   - name: {{ $policyName }}
     apiGroup: policy.open-cluster-management.io
     kind: Policy
+{{- end }}

--- a/policies/stable/cluster-config-maps/templates/raw-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/raw-config-maps.yaml
@@ -1,8 +1,17 @@
-{{- $defaultConfigs := (index $.Values "config" | default dict) }}
+{{- $defaultConfig := (index $.Values "config" | default dict) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: 
+  name: "{{ .Release.Name | replace "cluster-config-maps" "" }}default-configs"
+  namespace: "{{ $.Values.policy_namespace }}" 
+  labels:
+    autoshift.io/cluster-default-configs: ""
+data:
+  config: '{{ $defaultConfig | toJson }}'
+
 {{- range $clusterName, $cluster := $.Values.clusters }}
-{{- $clusterConfig := (dict) }}
-{{- $_ := (merge $clusterConfig (index $cluster "config" | default dict) $defaultConfigs) }}
-  {{- if not (empty $clusterConfig) }}
+{{- $clusterConfig := (index $cluster "config" | default dict) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -12,17 +21,14 @@ metadata:
   labels:
     autoshift.io/cluster-configs: ""
 data:
-    config: '{{ $clusterConfig | toJson }}'
-  {{- end }}
+  config: '{{ $clusterConfig | toJson }}'
 {{- end }}
 
 {{- $clusterSets := (dict) }}
 {{- $hubClusterSets := (index $.Values "hubClusterSets" | default dict) }}
 {{- $managedClusterSets := (index $.Values "managedClusterSets" | default dict) }}
 {{- range $clusterSetName, $clusterSet := (merge $clusterSets $hubClusterSets $managedClusterSets) }}
-{{- $clusterSetConfig := (dict) }}
-{{- $_ := (merge $clusterSetConfig (index $clusterSet "config" | default dict) $defaultConfigs) }}
-  {{- if not (empty $clusterSetConfig) }}
+{{- $clusterSetConfig := (index $clusterSet "config" | default dict) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -32,7 +38,5 @@ metadata:
   labels:
     autoshift.io/cluster-set-configs: ""
 data:
-    config: '{{ $clusterSetConfig | toJson }}'
-  {{- end }}
+  config: '{{ $clusterSetConfig | toJson }}'
 {{- end }}
----


### PR DESCRIPTION
multiple autoshift deployment along with namespaced/deployment tenancy for cluster-specific config maps

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] New policy (new operator or cluster configuration)
- [ ] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [x] Other: updates the config map rendering policy to support rendering config maps across policy namespaces, in effect making it work for multiple versions of autoshift and allowing each autoshift deployment to act as a separate tenant that can then define its own desired configs for a given cluster, which only get applied if that cluster is owned by said autoshift deployment via clusterset membership

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
