### PR TITLE
bump Go toolchain to 1.25.11 to fix govulncheck CVEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ release-artifacts/
 .tmp
 .tmp/*
 local/
+memory

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-shift/autoshiftv2/tools
 
-go 1.25.9
+go 1.25.11
 
 require (
 	github.com/stolostron/go-template-utils/v7 v7.3.0


### PR DESCRIPTION
  Bumps the go directive in tools/go.mod from 1.25.9 to 1.25.11 to
  resolve two Go standard library vulnerabilities flagged by govulncheck
  in CI:

  - GO-2026-5039: unescaped inputs in net/textproto errors (fixed 1.25.11)
  - GO-2026-5037: inefficient hostname parsing in crypto/x509 (fixed 1.25.11)