### PR TITLE
Updating NFD discovery instance configuration

### DIFF
--- a/policies/stable/node-feature-discovery/templates/policy-node-feature-discovery-instance.yaml
+++ b/policies/stable/node-feature-discovery/templates/policy-node-feature-discovery-instance.yaml
@@ -109,12 +109,10 @@ spec:
                             - "DMI"
                         pci:
                           deviceClassWhitelist:
-                            - "0200"
-                            - "03"
+                            - "0300"
                             - "0302"
-                            - "12"
                           deviceLabelFields:
-                            - "class"
+                            - "vendor"
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement


### PR DESCRIPTION
## Description

Updated NFD instance policy PCI config so clusters can discover NVIDIA GPUs. Narrowed deviceClassWhitelist to 0300 and 0302 (removed generic/broad classes like 0200, 03, 12) and changed deviceLabelFields from class to vendor so NFD emits pci-10de.present labels the NVIDIA GPU Operator requires.

## Type of Change
Configuration fix

## Checklist
- PCI whitelist aligned with NVIDIA NFD recommendations
- Label fields produce vendor-specific GPU labels (pci-10de)
- Verified on cluster (oc get nodes -l feature.node.kubernetes.io/pci-10de.present=true)
