### PR TITLE
  AutoShift clusters have two CRDs named "applications" (app.k8s.io f…

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -279,7 +279,7 @@ git commit -m "Add my-component operator with configuration"
 git push
 
 # Monitor deployment in ArgoCD
-oc get applications -n openshift-gitops | grep my-component
+oc get applications.argoproj.io -n openshift-gitops | grep my-component
 ```
 
 ## 📚 Policy Development Guide
@@ -519,7 +519,7 @@ oc get policies -A | grep my-component
 oc describe policy policy-my-component-operator-install -n policies-autoshift
 
 # View ArgoCD sync status
-oc get applications -n openshift-gitops my-component -o yaml
+oc get applications.argoproj.io -n openshift-gitops my-component -o yaml
 ```
 
 ### Working with Disconnected Environments
@@ -737,7 +737,7 @@ oc get policyreports -A
 | Policy not applying to cluster | Check cluster labels: `oc get managedcluster $CLUSTER_NAME -o yaml` |
 | Operator installation failing | Check OperatorPolicy status: `oc describe operatorpolicy OPERATOR_POLICY_NAME -n $CLUSTER_NAME` |
 | Template rendering errors | Check policy status: `oc describe policy POLICY_NAME -n policies-autoshift` |
-| ArgoCD sync failures | Check application status: `oc get applications -n openshift-gitops POLICY_NAME -o yaml` |
+| ArgoCD sync failures | Check application status: `oc get applications.argoproj.io -n openshift-gitops POLICY_NAME -o yaml` |
 | Policy stuck in NonCompliant | Check OperatorPolicy or ConfigurationPolicy status (see debug commands) |
 | Configuration not applied | Check ConfigurationPolicy status: `oc describe configurationpolicy CONFIG_POLICY_NAME -n $CLUSTER_NAME` |
 | Hub template processing issues | View policy propagator logs (see debug commands) |
@@ -767,10 +767,10 @@ oc describe configurationpolicy CONFIG_POLICY_NAME -n $CLUSTER_NAME
 oc describe policy POLICY_NAME -n policies-autoshift
 
 # 4. Check ArgoCD application status
-oc get applications -n openshift-gitops
+oc get applications.argoproj.io -n openshift-gitops
 
 # 5. View specific ArgoCD application details
-oc get application autoshift-POLICY_NAME -n openshift-gitops -o yaml
+oc get application.argoproj.io autoshift-POLICY_NAME -n openshift-gitops -o yaml
 
 # 6. Check cluster labels (hub template variables)
 oc get managedcluster $CLUSTER_NAME -o yaml

--- a/docs/gradual-rollout.md
+++ b/docs/gradual-rollout.md
@@ -112,7 +112,7 @@ oc label managedcluster spoke-cluster-3 cluster.open-cluster-management.io/clust
 
 ```bash
 # Check Application synced
-oc get application autoshift-0-0-1 -n openshift-gitops
+oc get application.argoproj.io autoshift-0-0-1 -n openshift-gitops
 
 # Check policy namespace (uses ArgoCD app name)
 oc get namespace policies-autoshift-0-0-1
@@ -225,7 +225,7 @@ oc get managedclusters -l cluster.open-cluster-management.io/clusterset=managed-
 # Should return empty
 
 # Delete old AutoShift deployment
-oc delete application autoshift-0-0-1 -n openshift-gitops
+oc delete application.argoproj.io autoshift-0-0-1 -n openshift-gitops
 
 # Clustersets will be cleaned up with the application, or manually:
 oc delete managedclusterset hub-0-0-1 managed-0-0-1

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -201,10 +201,10 @@ Alternatively, you can assign clusters via the ACM Console at **All Clusters > I
 
 ```bash
 # Check ArgoCD Application
-oc get application autoshift -n openshift-gitops
+oc get application.argoproj.io autoshift -n openshift-gitops
 
 # Check individual policy Applications
-oc get applications -n openshift-gitops | grep autoshift
+oc get applications.argoproj.io -n openshift-gitops | grep autoshift
 
 # Check ACM policies
 oc get policies -A
@@ -367,10 +367,10 @@ oc label managedcluster <cluster-name> cluster.open-cluster-management.io/cluste
 
 ```bash
 # Check ArgoCD Application
-oc get application autoshift -n openshift-gitops
+oc get application.argoproj.io autoshift -n openshift-gitops
 
 # Check individual policy Applications
-oc get applications -n openshift-gitops | grep autoshift
+oc get applications.argoproj.io -n openshift-gitops | grep autoshift
 
 # Check ACM policies
 oc get policies -A
@@ -408,8 +408,8 @@ oc describe policy <policy-name> -n open-cluster-policies
 
 ### ArgoCD Application not syncing
 ```bash
-oc get application autoshift -n openshift-gitops -o yaml
-oc describe application autoshift -n openshift-gitops
+oc get application.argoproj.io autoshift -n openshift-gitops -o yaml
+oc describe application.argoproj.io autoshift -n openshift-gitops
 ```
 
 ## Next Steps

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -293,7 +293,7 @@ AutoShift also provides an ImageSet generator for mirroring operator images. See
 To upgrade or pin to a specific version, set `targetRevision` on the ArgoCD Application:
 
 ```bash
-oc patch application autoshift -n openshift-gitops \
+oc patch application.argoproj.io autoshift -n openshift-gitops \
   --type=merge \
   -p '{"spec":{"source":{"targetRevision":"X.Y.Z"}}}'
 ```
@@ -340,7 +340,7 @@ oc get applicationset -n openshift-gitops -o yaml
 oc logs -n openshift-gitops deployment/argocd-applicationset-controller --tail=100
 
 # Verify OCI mode is enabled
-oc get application autoshift -n openshift-gitops -o yaml | grep autoshiftOciRegistry
+oc get application.argoproj.io autoshift -n openshift-gitops -o yaml | grep autoshiftOciRegistry
 ```
 
 ### Policy charts not found in registry
@@ -350,7 +350,7 @@ oc get application autoshift -n openshift-gitops -o yaml | grep autoshiftOciRegi
 helm pull oci://quay.io/autoshift/policies/advanced-cluster-security
 
 # Verify all charts are the same version
-oc get applications -n openshift-gitops -o custom-columns=NAME:.metadata.name,REVISION:.spec.source.targetRevision | grep autoshift
+oc get applications.argoproj.io -n openshift-gitops -o custom-columns=NAME:.metadata.name,REVISION:.spec.source.targetRevision | grep autoshift
 ```
 
 ## Support

--- a/scripts/deploy-oci.sh
+++ b/scripts/deploy-oci.sh
@@ -267,7 +267,7 @@ EOF
         log "✓ ArgoCD Application created"
         echo ""
         log "Monitor deployment:"
-        echo "  oc get application ${RELEASE_NAME} -n ${NAMESPACE} -w"
+        echo "  oc get application.argoproj.io ${RELEASE_NAME} -n ${NAMESPACE} -w"
         echo ""
         log "View in ArgoCD UI:"
         echo "  oc get route argocd-server -n ${NAMESPACE}"
@@ -318,7 +318,7 @@ elif [ "$METHOD" = "helm" ]; then
         echo "  helm status ${RELEASE_NAME} -n ${NAMESPACE}"
         echo ""
         log "Verify deployment:"
-        echo "  oc get applications -n ${NAMESPACE}"
+        echo "  oc get applications.argoproj.io -n ${NAMESPACE}"
         echo "  oc get policies -A"
     fi
 fi

--- a/scripts/generate-bootstrap-installer.sh
+++ b/scripts/generate-bootstrap-installer.sh
@@ -305,7 +305,7 @@ echo ""
 
 log "Monitoring sync status..."
 sleep 5
-oc get application ${APP_NAME} -n ${GITOPS_NAMESPACE}
+oc get application.argoproj.io ${APP_NAME} -n ${GITOPS_NAMESPACE}
 
 echo ""
 log "========================================="
@@ -313,9 +313,9 @@ log "AutoShift installation initiated!"
 log "========================================="
 echo ""
 log "Monitor deployment:"
-echo "  oc get application ${APP_NAME} -n ${GITOPS_NAMESPACE} -w"
+echo "  oc get application.argoproj.io ${APP_NAME} -n ${GITOPS_NAMESPACE} -w"
 echo "  oc get applicationset -n ${GITOPS_NAMESPACE}"
-echo "  oc get applications -n ${GITOPS_NAMESPACE} | grep ${APP_NAME}"
+echo "  oc get applications.argoproj.io -n ${GITOPS_NAMESPACE} | grep ${APP_NAME}"
 echo ""
 log "View policies:"
 echo "  oc get policies -A"
@@ -506,13 +506,13 @@ EOF
 
 ```bash
 # Check AutoShift Application
-oc get application autoshift -n openshift-gitops
+oc get application.argoproj.io autoshift -n openshift-gitops
 
 # Check ApplicationSet (deploying policy charts)
 oc get applicationset -n openshift-gitops
 
 # Check individual policy Applications
-oc get applications -n openshift-gitops | grep autoshift
+oc get applications.argoproj.io -n openshift-gitops | grep autoshift
 
 # Verify ACM policies are created
 oc get policies -A
@@ -665,7 +665,7 @@ oc label managedcluster spoke-1 cluster.open-cluster-management.io/clusterset=ma
 
 # After validation, migrate remaining clusters
 # Then delete old version
-oc delete application autoshift-1-0-0 -n openshift-gitops
+oc delete application.argoproj.io autoshift-1-0-0 -n openshift-gitops
 ```
 
 See [Gradual Rollout Guide](https://github.com/auto-shift/autoshiftv2/blob/main/docs/gradual-rollout.md) for detailed instructions.
@@ -745,7 +745,7 @@ oc describe mch multiclusterhub -n open-cluster-management
 
 ```bash
 # Check Application sync status
-oc get application autoshift -n openshift-gitops -o yaml
+oc get application.argoproj.io autoshift -n openshift-gitops -o yaml
 
 # Check ApplicationSet status
 oc get applicationset -n openshift-gitops -o yaml
@@ -788,7 +788,7 @@ GUIDE_VERSION
 cat >> "$ARTIFACTS_DIR/INSTALL.md" << 'GUIDE_EOF'
 
 # Upgrade AutoShift Application
-oc patch application autoshift -n openshift-gitops \
+oc patch application.argoproj.io autoshift -n openshift-gitops \
   --type=merge \
   -p '{"spec":{"source":{"targetRevision":"<NEW_VERSION>"}}}'
 ```


### PR DESCRIPTION
## Description

  Qualify every `oc <verb> application[s]` as `application[s].argoproj.io`
  across the docs and bootstrap/deploy scripts (get/describe/delete/patch).
  applicationset references are left as-is since that kind is unambiguous.

## Type of Change

- [x] Bug fix (incorrect template, label logic, chart rendering)
- [x] Documentation update

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)
