### PR TITLE
Fixing duplicate deployments of cluster-labels cluster-config-maps for oci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,12 @@ jobs:
           fi
 
           POLICY_COUNT=$(wc -l < autoshift/files/policy-list.txt | tr -d ' ')
-          EXPECTED=$(find policies -maxdepth 3 -name Chart.yaml | wc -l | tr -d ' ')
+          # cluster-labels and cluster-config-maps are deployed as dedicated Applications
+          # (full label/config data), not via the ApplicationSet list, so they are excluded
+          # from policy-list.txt. Keep this in sync with DEDICATED_APP_NAMES in the Makefile.
+          EXPECTED=$(find policies -maxdepth 3 -name Chart.yaml \
+            -not -path 'policies/*/cluster-labels/*' \
+            -not -path 'policies/*/cluster-config-maps/*' | wc -l | tr -d ' ')
 
           echo "policy-list.txt contains $POLICY_COUNT entries"
           echo "Expected $EXPECTED policies"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,12 @@ verify-policy-list:
       fi
 
       POLICY_COUNT=$(wc -l < autoshift/files/policy-list.txt | tr -d ' ')
-      EXPECTED=$(find policies -maxdepth 3 -name Chart.yaml | wc -l | tr -d ' ')
+      # cluster-labels and cluster-config-maps are deployed as dedicated Applications
+      # (full label/config data), not via the ApplicationSet list, so they are excluded
+      # from policy-list.txt. Keep this in sync with DEDICATED_APP_NAMES in the Makefile.
+      EXPECTED=$(find policies -maxdepth 3 -name Chart.yaml \
+        -not -path 'policies/*/cluster-labels/*' \
+        -not -path 'policies/*/cluster-config-maps/*' | wc -l | tr -d ' ')
 
       echo "policy-list.txt contains $POLICY_COUNT entries"
       echo "Expected $EXPECTED policies"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ NC := \033[0m
 BOOTSTRAP_CHARTS := $(shell find . -maxdepth 2 -name Chart.yaml -not -path "./policies/*" -not -path "./autoshift/*" -exec dirname {} \;)
 POLICY_CHARTS := $(shell find policies -maxdepth 3 -name Chart.yaml -exec dirname {} \;)
 POLICY_NAMES := $(notdir $(POLICY_CHARTS))
+# Charts deployed as dedicated Applications (full label/config data), NOT via the ApplicationSet list.
+# Still packaged/pushed to OCI, but must be kept out of policy-list.txt to avoid a duplicate Application.
+DEDICATED_APP_NAMES := cluster-labels cluster-config-maps
+POLICY_LIST_NAMES := $(filter-out $(DEDICATED_APP_NAMES),$(POLICY_NAMES))
 
 .PHONY: discover
 discover: ## Discover all charts in the repository
@@ -96,10 +100,11 @@ sync-values: ## Sync bootstrap chart values from policy charts
 
 .PHONY: generate-policy-list
 generate-policy-list: ## Generate policy-list.txt for OCI mode
-	@printf "$(BLUE)[INFO]$(NC) Generating policy-list.txt with $(words $(POLICY_NAMES)) policies...\n"
+	@printf "$(BLUE)[INFO]$(NC) Generating policy-list.txt with $(words $(POLICY_LIST_NAMES)) policies...\n"
 	@mkdir -p autoshift/files
-	@$(foreach policy,$(POLICY_NAMES),echo "$(policy)" >> autoshift/files/policy-list.txt;)
-	@printf "$(GREEN)✓$(NC) Generated policy-list.txt with $(words $(POLICY_NAMES)) policies\n"
+	@rm -f autoshift/files/policy-list.txt
+	@$(foreach policy,$(POLICY_LIST_NAMES),echo "$(policy)" >> autoshift/files/policy-list.txt;)
+	@printf "$(GREEN)✓$(NC) Generated policy-list.txt with $(words $(POLICY_LIST_NAMES)) policies\n"
 
 .PHONY: package-charts
 package-charts: ## Package all Helm charts


### PR DESCRIPTION
## Description

Fixing duplicate deployments of cluster-labels cluster-config-maps for oci

## Type of Change

- [x] Bug fix (incorrect template, label logic, chart rendering)

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)

