### PR TITLE
Adding Demo documentation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,6 +139,9 @@ open-cluster-management   multiclusterhub   Running      6m28s   2.13.2         
 > [!TIP]
 > The previously installed OpenShift GitOps and ACM will be controlled by AutoShift after it is installed for version upgrading
 
+> [!TIP]
+> **Just developing or demoing?** Skip the ArgoCD Application below and install AutoShift with `helm` straight from your working copy — edit a values file and re-apply, no commit/push/ArgoCD sync required. See [Alternative (development): Deploy directly with Helm](#alternative-development-deploy-directly-with-helm) just below.
+
 Update your values file with desired feature flags and repo url as defined in the [Autoshift Cluster Labels Values Reference](values-reference.md).
 
 Using helm and the values you set for cluster labels, install AutoShift. Here is an example using the hub values file:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,9 @@
 
 This guide walks through a complete AutoShift installation from start to finish.
 
+> [!TIP]
+> **Just want to try AutoShift or see how a values change behaves?** There is a fast, local-only path that installs AutoShift with `helm` from your working copy — edit a values file and re-apply, no commit/push/ArgoCD sync required. It is for **development and demos, not production**. See [Alternative (development): Deploy directly with Helm](#alternative-development-deploy-directly-with-helm).
+
 ## Prerequisites
 
 * A Red Hat OpenShift cluster at 4.20+ to act as the **hub** cluster
@@ -179,6 +182,45 @@ spec:
       selfHeal: true
 EOF
 ```
+
+#### Alternative (development): Deploy directly with Helm
+
+> [!WARNING]
+> This path is for **development and demos only, not production**. It installs the AutoShift ApplicationSet with `helm` from your local working copy instead of creating the `autoshift` ArgoCD Application. Production deployments should use the ArgoCD Application above so that AutoShift is self-managed and reconciled by GitOps.
+
+Instead of pointing an ArgoCD Application at values files committed in Git, you can render the `autoshift` chart directly against your **local** values files. This lets you edit a values file and re-apply immediately — no commit, push, or ArgoCD sync round-trip — which is the fastest way to see how a values change behaves.
+
+Run this from the **root of your clone**:
+
+```console
+helm upgrade --install autoshift ./autoshift \
+  -n openshift-gitops \
+  -f autoshift/values/global.yaml \
+  -f autoshift/values/clustersets/hub.yaml \
+  -f autoshift/values/clustersets/managed.yaml
+```
+
+Add any per-cluster override files the same way (for example `-f autoshift/values/clusters/my-cluster.yaml`). To iterate, edit a values file and re-run the same command — Helm re-renders the ApplicationSet with your new values.
+
+> [!IMPORTANT]
+> Only **values** are read locally. The ApplicationSet still pulls the policy **charts** from Git (`autoshiftGitRepo` / `autoshiftGitBranchTag`, default `auto-shift/autoshiftv2` @ `main`). So local edits to *values files* take effect on the next `helm upgrade`, but edits to *policy templates* only apply after you push them and point the chart at that branch:
+> ```console
+> helm upgrade --install autoshift ./autoshift -n openshift-gitops \
+>   --set autoshiftGitRepo=https://github.com/<you>/autoshiftv2.git \
+>   --set autoshiftGitBranchTag=<your-branch> \
+>   -f autoshift/values/global.yaml \
+>   -f autoshift/values/clustersets/hub.yaml \
+>   -f autoshift/values/clustersets/managed.yaml
+> ```
+
+Because Helm owns the ApplicationSet in this mode, there is **no** `autoshift` ArgoCD Application — so `oc get application.argoproj.io autoshift` (used in Step 6) will not exist. Verify with the ApplicationSet and the generated per-policy Applications instead:
+
+```console
+oc get applicationset autoshift-policies -n openshift-gitops
+oc get applications.argoproj.io -n openshift-gitops
+```
+
+To remove it: `helm uninstall autoshift -n openshift-gitops`.
 
 ### Step 5: Assign Clusters to ClusterSets
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -140,7 +140,7 @@ open-cluster-management   multiclusterhub   Running      6m28s   2.13.2         
 > The previously installed OpenShift GitOps and ACM will be controlled by AutoShift after it is installed for version upgrading
 
 > [!TIP]
-> **Just developing or demoing?** Skip the ArgoCD Application below and install AutoShift with `helm` straight from your working copy — edit a values file and re-apply, no commit/push/ArgoCD sync required. See [Alternative (development): Deploy directly with Helm](#alternative-development-deploy-directly-with-helm) just below.
+> **Just developing or demoing?** Skip the ArgoCD Application below and install AutoShift with `helm` straight from your working copy. Edit a values file and re-apply, no commit/push/ArgoCD sync required. See [Alternative (development): Deploy directly with Helm](#alternative-development-deploy-directly-with-helm) just below.
 
 Update your values file with desired feature flags and repo url as defined in the [Autoshift Cluster Labels Values Reference](values-reference.md).
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-shift/autoshiftv2/tools
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/stolostron/go-template-utils/v7 v7.3.0


### PR DESCRIPTION
Signed-off-by: Ben Carr <9310348+bcarr-rh@users.noreply.github.com>

## Description

Add documentation for local value changes for demoing autoshift

## Type of Change

- [x] Documentation update

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
