### PR TITLE
Add hosted-control-planes policy: enable HyperShift on the MultiClusterEngine

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -944,6 +944,14 @@ hubClusterSets:
       virt-source-namespace: openshift-marketplace
 
       # =======================================================================
+      # Hosted Control Planes (HyperShift)
+      # =======================================================================
+      # Enables the hypershift + hypershift-local-hosting components on the hub's
+      # MultiClusterEngine (created by ACM). No OLM Subscription — just the toggle.
+      # Typically paired with virt (KubeVirt hosting) and metallb/an external LB.
+      hcp: 'false'
+
+      # =======================================================================
       # Migration Toolkit for Virtualization
       # =======================================================================
       mtv: 'false'

--- a/policies/stable/hosted-control-planes/README.md
+++ b/policies/stable/hosted-control-planes/README.md
@@ -1,0 +1,42 @@
+# Hosted Control Planes (HyperShift)
+
+This AutoShift policy enables **Hosted Control Planes (HyperShift)** on the hub so it can host
+OpenShift control planes — for example, KubeVirt-based hosted clusters whose worker nodes run as
+VMs on OpenShift Virtualization.
+
+Unlike most AutoShift policies, HyperShift is **not** installed as an OLM operator. It is enabled
+by turning on two components of the **MultiClusterEngine (MCE)** that ACM creates: `hypershift`
+and `hypershift-local-hosting`. This policy reads the live MCE and flips only those two components
+to `enabled`, preserving every other component (a plain `musthave` on the component list would risk
+duplicate entries).
+
+## Enabling
+
+Set the toggle in your clusterset values file (e.g. `autoshift/values/clustersets/hub.yaml`):
+
+```yaml
+hcp: 'true'
+```
+
+The policy is **hub-targeted** — the MCE lives on the hub — and gated by the `autoshift.io/hcp`
+label. It takes effect once ACM's MultiClusterHub has created the MultiClusterEngine; until then
+the ConfigurationPolicy is a no-op.
+
+## Prerequisites
+
+- **ACM / MultiClusterHub** installed on the hub (this creates the MultiClusterEngine).
+- For **KubeVirt** hosted clusters: enable `virt` (OpenShift Virtualization) on the hosting
+  cluster(s), plus a LoadBalancer for the hosted cluster's API/ingress — MetalLB (`metallb`) or an
+  external load balancer fronting NodePorts.
+
+## What it does
+
+Delivers a single ConfigurationPolicy (`enable-hypershift`) that ensures the MCE's
+`spec.overrides.components` has:
+
+- `hypershift` → `enabled: true`
+- `hypershift-local-hosting` → `enabled: true`
+
+Enabling `hypershift-local-hosting` also installs the `hypershift-addon` on `local-cluster`, so the
+hub can host control planes locally. Creating actual `HostedCluster` / `NodePool` resources is a
+separate, per-use step (a follow-on policy can add a sample).

--- a/policies/stable/hosted-control-planes/kustomization.yaml
+++ b/policies/stable/hosted-control-planes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - policy-generator-config.yaml

--- a/policies/stable/hosted-control-planes/manifests/enable-hypershift.yaml
+++ b/policies/stable/hosted-control-planes/manifests/enable-hypershift.yaml
@@ -1,0 +1,39 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: enable-hypershift
+spec:
+  remediationAction: ${REMEDIATION}
+  severity: high
+  # Hosted Control Planes are enabled through the MultiClusterEngine's `hypershift` and
+  # `hypershift-local-hosting` components (not an OLM Subscription). The MCE is owned by the ACM
+  # MultiClusterHub, so we read the live component list and flip ONLY those two to enabled, then
+  # re-apply the whole list with mustonlyhave — this preserves every other MCE component and avoids
+  # the duplicate entries a plain musthave on a list would create. Skipped until the MCE exists.
+  object-templates-raw: |
+    {{hub- $mce := (lookup "multicluster.openshift.io/v1" "MultiClusterEngine" "" "multiclusterengine") hub}}
+    {{hub- if $mce hub}}
+    {{hub- $components := (dig "spec" "overrides" "components" (list) $mce) hub}}
+    {{hub- $out := list hub}}
+    {{hub- $have := dict hub}}
+    {{hub- range $c := $components hub}}
+      {{hub- $n := (dig "name" "" $c) hub}}
+      {{hub- $_ := set $have $n true hub}}
+      {{hub- if or (eq $n "hypershift") (eq $n "hypershift-local-hosting") hub}}
+      {{hub- $out = append $out (merge (dict "enabled" true) $c) hub}}
+      {{hub- else hub}}
+      {{hub- $out = append $out $c hub}}
+      {{hub- end hub}}
+    {{hub- end hub}}
+    {{hub- if not (hasKey $have "hypershift") hub}}{{hub- $out = append $out (dict "name" "hypershift" "enabled" true) hub}}{{hub- end hub}}
+    {{hub- if not (hasKey $have "hypershift-local-hosting") hub}}{{hub- $out = append $out (dict "name" "hypershift-local-hosting" "enabled" true) hub}}{{hub- end hub}}
+    - complianceType: mustonlyhave
+      objectDefinition:
+        apiVersion: multicluster.openshift.io/v1
+        kind: MultiClusterEngine
+        metadata:
+          name: multiclusterengine
+        spec:
+          overrides:
+            components: {{hub $out | toRawJson hub}}
+    {{hub- end hub}}

--- a/policies/stable/hosted-control-planes/placement.yaml
+++ b/policies/stable/hosted-control-planes/placement.yaml
@@ -1,0 +1,21 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-hcp
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  # No spec.clusterSets: selected via ManagedClusterSetBindings in this namespace + the predicate.
+  # The MultiClusterEngine lives on the hub, so this targets the hub via the autoshift.io/hcp label.
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/hcp'
+              operator: In
+              values:
+                - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/stable/hosted-control-planes/policy-generator-config.yaml
+++ b/policies/stable/hosted-control-planes/policy-generator-config.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: hosted-control-planes
+# Enables HyperShift / Hosted Control Planes on the hub by turning on the `hypershift` and
+# `hypershift-local-hosting` components of the existing MultiClusterEngine (created by the ACM
+# MultiClusterHub). Hub-targeted (the MCE lives on the hub); gated by the autoshift.io/hcp label.
+# The enablement is a first-class ConfigurationPolicy (manifests/enable-hypershift.yaml) that reads
+# the live MCE and flips only those two components, so the rest of the component list is preserved.
+placementBindingDefaults:
+  name: binding-policy-hcp
+policyDefaults:
+  namespace: ${POLICY_NAMESPACE}
+  remediationAction: ${REMEDIATION}
+  severity: high
+  consolidateManifests: true
+  evaluationInterval:
+    compliant: ${EVAL_COMPLIANT}
+    noncompliant: ${EVAL_NONCOMPLIANT}
+  standards:
+    - NIST SP 800-53
+  categories:
+    - CM Configuration Management
+  controls:
+    - CM-2 Baseline Configuration
+  placement:
+    placementPath: placement.yaml
+policies:
+  - name: policy-hcp-enable-hypershift
+    manifests:
+      - path: manifests/enable-hypershift.yaml

--- a/tools/testdata/multiclusterengine.yaml
+++ b/tools/testdata/multiclusterengine.yaml
@@ -1,0 +1,21 @@
+---
+# Fake MultiClusterEngine (used by the hosted-control-planes policy to enable the hypershift and
+# hypershift-local-hosting components). Mirrors the component list ACM's MultiClusterHub creates,
+# with the two hypershift components disabled, so the policy's read-merge-write is exercised.
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec:
+  overrides:
+    components:
+      - name: hypershift
+        enabled: false
+      - name: hypershift-local-hosting
+        enabled: false
+      - name: local-cluster
+        enabled: true
+      - name: managedserviceaccount
+        enabled: true
+      - name: cluster-lifecycle
+        enabled: true


### PR DESCRIPTION
## Description

Adds a `hosted-control-planes` policy that enables **HyperShift / Hosted Control Planes** on the hub by turning on the `hypershift` and `hypershift-local-hosting` components of the MultiClusterEngine (created by the ACM MultiClusterHub). There are currently no HyperShift references in the repo, so this fills a gap — it pairs naturally with the existing `openshift-virtualization` and `metallb` policies to enable HCP-on-KubeVirt fleets.

**HyperShift is enabled via MCE components, not an OLM Subscription**, so this is a config policy rather than an `operator-install` policy. The enablement (`manifests/enable-hypershift.yaml`) is a `ConfigurationPolicy` using `object-templates-raw` that:

1. `lookup`s the live `MultiClusterEngine`,
2. flips **only** the `hypershift` and `hypershift-local-hosting` components to `enabled: true` (preserving every other component),
3. re-applies the resolved component list with `mustonlyhave`.

This avoids the duplicate list-entry problem a plain `musthave` on `spec.overrides.components` would cause. Gated by a new `autoshift.io/hcp` label; hub-targeted. A `MultiClusterEngine` stub was added to `tools/testdata/` so the hub-template `lookup` resolves in the resolver suite.

## Type of Change

- [x] New policy (new operator or cluster configuration)

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` — **hand-authored**: HyperShift isn't an OLM operator, so the Subscription-based scaffold didn't fit. Modeled on `openshift-virtualization` + the `object-templates-raw` pattern from `metallb`.
- [x] Renders without errors via the PolicyGenerator toolchain (`make install-policy-generator` + kustomize plugin)
- [x] `cd tools && go test -tags integration ./...` passes — resolver suite renders clean, the hub template resolves, label contract **392 OK / 0 missing / 0 orphaned**
- [x] New `autoshift.io/hcp` label declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name` / `channel` / `source` / `source-namespace` labels — **N/A**: not an OLM operator (MCE-component enablement)
- [x] Policy `README.md` included
- [x] No hardcoded values — hub-template `lookup`/merge used for the MCE
- [ ] Tested in a dev/sandbox environment — **not yet** (offline validation only; see note)
- [x] Commits signed off (DCO)

## Note for reviewers (why draft)

Offline validation (PolicyGenerator render + resolver suite) passes, but this has **not yet been validated on a live hub**. The one behavior worth confirming on-cluster: whether `mustonlyhave` on the nested `spec.overrides.components` list preserves the MCE's other spec fields (e.g. `availabilityConfig`) at runtime, or needs adjusting. Opening as a draft to get maintainer feedback on the approach before marking ready.

Natural follow-ups (kept out of this PR per one-feature-per-PR): the `hypershift-addon` `ManagedClusterAddOn` for designated hosting clusters, and a sample KubeVirt `HostedCluster` / `NodePool` policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)