### PR TITLE
Image Registry Nooba CA Fix

### DIFF
--- a/policies/stable/ansible-automation-platform/policy-generator-config.yaml
+++ b/policies/stable/ansible-automation-platform/policy-generator-config.yaml
@@ -42,6 +42,9 @@ policies:
   - name: policy-aap-nooba-storage
     dependencies:
       - name: policy-aap-operator-install
+      # An ObjectBucketClaim created before the NooBaa StorageClass exists is never reconciled —
+      # it stays phaseless forever instead of retrying. Gate on ODF being ready.
+      - name: policy-storage-cluster-test
     placement:
       placementPath: placement-nooba-storage.yaml
     manifests:

--- a/policies/stable/openshift-image-registry/manifests/enable-image-registry.yaml
+++ b/policies/stable/openshift-image-registry/manifests/enable-image-registry.yaml
@@ -3,13 +3,18 @@ object-templates-raw: |
   {{- $noobaaHost := (index ($noobaaRoute.spec | default dict) "host" | default "") }}
   {{- $caBundleCert := fromConfigMap "openshift-image-registry" "openshift-service-ca.crt" "service-ca.crt" }}
   {{- if not (empty $noobaaHost) }}
-  {{- /* The NooBaa S3 endpoint is an apps route, so trust whatever signs the default ingress cert.
-         Use openshift-config-managed/default-ingress-cert: the ingress operator keeps it in sync with
-         the cert actually in use, custom or operator-generated. The router-ca secret only matches when
-         the cluster still uses the operator's self-signed cert, so it is wrong on any cluster with a
-         replaced defaultCertificate — including one where AutoShift's own cert-manager policy set it. */ -}}
+  {{- /* The NooBaa S3 endpoint is an apps route, so the bundle also needs whatever signs the default
+         ingress cert. openshift-config-managed/default-ingress-cert is published by the ingress
+         operator and tracks the cert actually in use, custom or operator-generated; the router-ca
+         secret only matches while the cluster still uses the operator's self-signed cert, so it goes
+         stale on any cluster with a replaced defaultCertificate — including one set by AutoShift's own
+         cert-manager policy. Append rather than replace, so the service CA stays as a floor and a
+         missing ConfigMap can never produce an empty bundle. */ -}}
   {{- $ingressCA := (lookup "v1" "ConfigMap" "openshift-config-managed" "default-ingress-cert") | default dict }}
-  {{- $caBundleCert = (index ($ingressCA.data | default dict) "ca-bundle.crt" | default "") }}
+  {{- $ingressPEM := (index ($ingressCA.data | default dict) "ca-bundle.crt" | default "") }}
+  {{- if not (empty $ingressPEM) }}
+  {{- $caBundleCert = printf "%s\n%s" (trim $caBundleCert) (trim $ingressPEM) }}
+  {{- end }}
   {{- end }}
   {{hub- if eq (index .ManagedClusterLabels "autoshift.io/imageregistry-storage-type" | default "") "s3" hub}}
   - complianceType: musthave

--- a/policies/stable/openshift-image-registry/manifests/enable-image-registry.yaml
+++ b/policies/stable/openshift-image-registry/manifests/enable-image-registry.yaml
@@ -3,8 +3,13 @@ object-templates-raw: |
   {{- $noobaaHost := (index ($noobaaRoute.spec | default dict) "host" | default "") }}
   {{- $caBundleCert := fromConfigMap "openshift-image-registry" "openshift-service-ca.crt" "service-ca.crt" }}
   {{- if not (empty $noobaaHost) }}
-  {{- $routerCA := (lookup "v1" "Secret" "openshift-ingress-operator" "router-ca") | default dict }}
-  {{- $caBundleCert = (index ($routerCA.data | default dict) "tls.crt" | default "" | base64dec) }}
+  {{- /* The NooBaa S3 endpoint is an apps route, so trust whatever signs the default ingress cert.
+         Use openshift-config-managed/default-ingress-cert: the ingress operator keeps it in sync with
+         the cert actually in use, custom or operator-generated. The router-ca secret only matches when
+         the cluster still uses the operator's self-signed cert, so it is wrong on any cluster with a
+         replaced defaultCertificate — including one where AutoShift's own cert-manager policy set it. */ -}}
+  {{- $ingressCA := (lookup "v1" "ConfigMap" "openshift-config-managed" "default-ingress-cert") | default dict }}
+  {{- $caBundleCert = (index ($ingressCA.data | default dict) "ca-bundle.crt" | default "") }}
   {{- end }}
   {{hub- if eq (index .ManagedClusterLabels "autoshift.io/imageregistry-storage-type" | default "") "s3" hub}}
   - complianceType: musthave

--- a/policies/stable/openshift-image-registry/manifests/image-registry-storage-s3.yaml
+++ b/policies/stable/openshift-image-registry/manifests/image-registry-storage-s3.yaml
@@ -1,0 +1,8 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: image-registry-storage
+  namespace: openshift-image-registry
+spec:
+  storageClassName: openshift-storage.noobaa.io
+  generateBucketName: image-registry-storage

--- a/policies/stable/openshift-image-registry/manifests/image-registry-storage.yaml
+++ b/policies/stable/openshift-image-registry/manifests/image-registry-storage.yaml
@@ -15,15 +15,4 @@ object-templates-raw: |
             storage: {{hub index .ManagedClusterLabels "autoshift.io/imageregistry-pvc-storage" | default "100Gi" hub}}
         volumeMode: {{hub index .ManagedClusterLabels "autoshift.io/imageregistry-pvc-volume-mode" | default "Filesystem" hub}}
         storageClassName: {{hub index .ManagedClusterLabels "autoshift.io/imageregistry-pvc-storage-class" hub}}
-  {{hub- else if eq (index .ManagedClusterLabels "autoshift.io/imageregistry-storage-type" | default "") "s3" hub}}
-  - complianceType: musthave
-    objectDefinition:
-      apiVersion: objectbucket.io/v1alpha1
-      kind: ObjectBucketClaim
-      metadata:
-        name: image-registry-storage
-        namespace: openshift-image-registry
-      spec:
-        storageClassName: openshift-storage.noobaa.io
-        generateBucketName: image-registry-storage
   {{hub- end hub}}

--- a/policies/stable/openshift-image-registry/placement-storage-s3.yaml
+++ b/policies/stable/openshift-image-registry/placement-storage-s3.yaml
@@ -1,0 +1,26 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-image-registry-storage-s3
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  # Dedicated placement so only s3-backed clusters get the ObjectBucketClaim policy — that policy
+  # depends on ODF being ready, and a shared placement would strand pvc-backed clusters in Pending
+  # (policy-storage-cluster-test is only placed where ODF is enabled).
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/imageregistry'
+              operator: In
+              values:
+                - 'true'
+            - key: 'autoshift.io/imageregistry-storage-type'
+              operator: In
+              values:
+                - 's3'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/stable/openshift-image-registry/policy-generator-config.yaml
+++ b/policies/stable/openshift-image-registry/policy-generator-config.yaml
@@ -30,11 +30,21 @@ policyDefaults:
   placement:
     placementPath: placement.yaml
 policies:
-  # Storage backing (PVC or NooBaa ObjectBucketClaim) + a Bound readiness check.
+  # PVC storage backing. Shares the default placement; the manifest is hub-gated on storage-type.
   - name: policy-image-registry-storage
     consolidateManifests: false
     manifests:
       - path: manifests/image-registry-storage.yaml
+  # s3 storage backing, split out because it must wait for ODF. An ObjectBucketClaim created before
+  # the NooBaa StorageClass exists is never reconciled — it stays phaseless instead of retrying.
+  # Own placement (storage-type: s3) so pvc-backed clusters aren't stranded by the ODF dependency.
+  - name: policy-image-registry-storage-s3
+    dependencies:
+      - name: policy-storage-cluster-test
+    placement:
+      placementPath: placement-storage-s3.yaml
+    manifests:
+      - path: manifests/image-registry-storage-s3.yaml
   # Enables the image registry Config; waits on storage to be provisioned.
   - name: policy-image-registry-storage-test
     remediationAction: inform


### PR DESCRIPTION
## Description

resolve race condition of OBC being created before noobaa was ready for the image registry. Added correct CA for image registry to talk to noobaa no matter what ingress cert is issued to the ingress controller.

## Type of Change

- [ ] New policy (new operator or cluster configuration)
- [x] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [ ] Other: <!-- describe -->

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
