### PR TITLE
Feature/autoshift UI

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -499,20 +499,21 @@ hubClusterSets:
       # =======================================================================
       # AutoShift Console Plugin (hub only; ENABLE flag is the autoshift-console label).
       # Read-only OpenShift console plugin that surfaces AutoShift clustersets, the resolution
-      # chain behind each setting, and policy compliance. Both keys are optional.
+      # chain behind each setting, and policy compliance. All keys are optional.
       # =======================================================================
       autoshiftConsole:
         # Built per OpenShift minor — the console supplies react and react-router as shared
-        # singletons, so one bundle cannot span releases. The tag names the minor it targets and
-        # there is no bare :latest. Pin a digest in production.
-        image: 'quay.io/autoshift/autoshift-console-plugin:ocp4.22'
+        # singletons, so one bundle cannot span releases. The policy appends ':ocp<minor>' using
+        # the cluster's ACTUAL running version, so a cluster always pulls its own build and a
+        # minor with no published build fails the pull rather than rendering nothing. Which minors
+        # are published is whatever is tagged in the repository:
+        # https://quay.io/repository/autoshift/autoshift-console-plugin?tab=tags
+        repository: 'quay.io/autoshift/autoshift-console-plugin'
         replicas: 2
-        # Minimum OpenShift version the plugin can run on. The policy reads the cluster's ACTUAL
-        # running version and deploys nothing below this, because an incompatible console skips
-        # the plugin silently — the pod runs and serves assets but nothing appears in the UI.
-        # Must match @console/pluginAPI in the plugin's package.json; ACM templates cannot read
-        # that file, so the two are kept in step by CI rather than derived.
-        minOpenShiftVersion: '4.22.0-0'
+        # Optional. Overrides repository and the derived tag outright — set it to pin a digest in
+        # production. Pinning one tag across a fleet spanning minors deploys the wrong bundle to
+        # all but one of them.
+        image: ''
     labels:
       # =======================================================================
       # Core Configuration
@@ -550,7 +551,7 @@ hubClusterSets:
 
       # =======================================================================
       # AutoShift Console Plugin (hub only — reads hub-side AutoShift ConfigMaps)
-      # Image and replicas are set under config.autoshiftConsole above.
+      # Repository and replicas are set under config.autoshiftConsole.
       # =======================================================================
       autoshift-console: 'true'                     # AutoShift section in the Fleet management perspective
 

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -552,7 +552,7 @@ hubClusterSets:
       # AutoShift Console Plugin (hub only — reads hub-side AutoShift ConfigMaps)
       # Image and replicas are set under config.autoshiftConsole above.
       # =======================================================================
-      autoshift-console: 'true'                     # add the AutoShift section to the console sidebar
+      autoshift-console: 'true'                     # AutoShift section in the Fleet management perspective
 
       # =======================================================================
       # Advanced Cluster Management (hub only — not installed on managed clusters)

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -496,6 +496,23 @@ hubClusterSets:
           provider: openshift               # '' disables the declarative auth config
           minimumRole: None                 # minimum role for authenticated users
           adminGroup: cluster-admins        # group mapped to the Admin role
+      # =======================================================================
+      # AutoShift Console Plugin (hub only; ENABLE flag is the autoshift-console label).
+      # Read-only OpenShift console plugin that surfaces AutoShift clustersets, the resolution
+      # chain behind each setting, and policy compliance. Both keys are optional.
+      # =======================================================================
+      autoshiftConsole:
+        # Built per OpenShift minor — the console supplies react and react-router as shared
+        # singletons, so one bundle cannot span releases. The tag names the minor it targets and
+        # there is no bare :latest. Pin a digest in production.
+        image: 'quay.io/autoshift/autoshift-console-plugin:ocp4.22'
+        replicas: 2
+        # Minimum OpenShift version the plugin can run on. The policy reads the cluster's ACTUAL
+        # running version and deploys nothing below this, because an incompatible console skips
+        # the plugin silently — the pod runs and serves assets but nothing appears in the UI.
+        # Must match @console/pluginAPI in the plugin's package.json; ACM templates cannot read
+        # that file, so the two are kept in step by CI rather than derived.
+        minOpenShiftVersion: '4.22.0-0'
     labels:
       # =======================================================================
       # Core Configuration
@@ -530,6 +547,12 @@ hubClusterSets:
       gitops-source-namespace: openshift-marketplace
       gitops-namespace: 'openshift-gitops'          # Override ArgoCD namespace per-cluster
       gitops-cluster-ca-bundle: 'true'              # Inject cluster trusted CA bundle into ArgoCD repo server
+
+      # =======================================================================
+      # AutoShift Console Plugin (hub only — reads hub-side AutoShift ConfigMaps)
+      # Image and replicas are set under config.autoshiftConsole above.
+      # =======================================================================
+      autoshift-console: 'true'                     # add the AutoShift section to the console sidebar
 
       # =======================================================================
       # Advanced Cluster Management (hub only — not installed on managed clusters)

--- a/autoshift/values/clustersets/hub.yaml
+++ b/autoshift/values/clustersets/hub.yaml
@@ -64,6 +64,8 @@ hubClusterSets:
       gitops-source: redhat-operators
       gitops-source-namespace: openshift-marketplace
       # gitops-namespace: 'openshift-gitops'  # Override ArgoCD namespace per-cluster
+      ### AutoShift Console Plugin
+      autoshift-console: 'true' # AutoShift section in the OpenShift console sidebar
       ### Advanced Cluster Manager
       acm-subscription-name: advanced-cluster-management
       # acm-version: 'advanced-cluster-management.v2.14.0'

--- a/policies/community/autoshift-console/README.md
+++ b/policies/community/autoshift-console/README.md
@@ -1,0 +1,83 @@
+# AutoShift Console Plugin
+
+Deploys the AutoShift OpenShift console dynamic plugin — a read-only **AutoShift** section in the
+Administrator sidebar (Fleet / Cluster Sets / Clusters / Stacks) that surfaces AutoShift's clustersets,
+resolved configuration, label drift and version tracking.
+
+Plugin source lives in a separate repository: `auto-shift/autoshift-console-plugin`.
+
+> Custom console plugin code is not supported by Red Hat — only Cooperative community support is
+> available. That is why this policy sits in the `community/` tier.
+
+## What it deploys
+
+| Resource | Purpose |
+|---|---|
+| `Namespace autoshift-console` | Plugin namespace, `pod-security.kubernetes.io/enforce: restricted` |
+| `ConfigMap autoshift-console-nginx-conf` | nginx TLS listener on 9443 serving the plugin assets |
+| `Deployment autoshift-console` | Serves the webpack module-federation bundle |
+| `Service autoshift-console` | ClusterIP 9443; service-ca mints `autoshift-console-cert` |
+| `ConsolePlugin autoshift-console` | Registers the plugin with the console |
+| `Console cluster` (patch) | Appends `autoshift-console` to `spec.plugins` |
+
+The `Console` patch uses `complianceType: musthave`, which **appends** to `spec.plugins`.
+`mustonlyhave` would evict every other console plugin on the cluster, including ACM's — do not change it.
+
+The two policies are split so the console is never pointed at a plugin whose Service does not exist
+yet: `policy-autoshift-console-enable` depends on `policy-autoshift-console`.
+
+## Placement
+
+Hub-only, opt-in. The Placement requires **both**:
+
+- `autoshift.io/cluster-type: 'hub'` — the plugin reads the cluster-labels, cluster-config and
+  rendered-config ConfigMaps, which only exist where an AutoShift instance runs (this includes spoke
+  hubs in a hub-of-hubs topology; each shows only the clusters its own ACM can see).
+- `autoshift.io/autoshift-console: 'true'`
+
+## Labels
+
+| Label | Default | Description |
+|---|---|---|
+| `autoshift.io/autoshift-console` | — | Set `'true'` to deploy the plugin |
+
+## Config
+
+Read from `config.autoshiftConsole` in the cluster's rendered-config ConfigMap. Both keys optional.
+
+```yaml
+hubClusterSets:
+  hub:
+    config:
+      autoshiftConsole:
+        image: 'quay.io/autoshift/autoshift-console-plugin:ocp4.22'
+        replicas: 2
+    labels:
+      autoshift-console: 'true'
+```
+
+Pin `image` to a released tag in production. In a disconnected environment the image is redirected by
+the cluster-wide `ImageDigestMirrorSet` the `disconnected-mirror` policy manages — no per-policy
+mirror suffix is involved, since this is a plain image rather than an OLM catalog source.
+
+## Stack grouping
+
+The plugin discovers components at runtime from ArgoCD Applications, Placements, PlacementDecisions
+and Policies, so a newly added AutoShift policy appears with no plugin rebuild. The only thing it
+cannot derive is which components form an application stack. That resolves in order:
+
+1. `ConfigMap autoshift-console-catalog` in the `autoshift-console` namespace, if an admin creates one
+2. the default catalog baked into the plugin image
+3. auto-grouping by config key, with anything unmatched under **Other**
+
+## Verification
+
+```bash
+oc get policy -n policies-autoshift | grep autoshift-console
+oc get consoleplugin autoshift-console
+oc get pods -n autoshift-console
+# must still list ACM's plugins alongside autoshift-console
+oc get console.operator.openshift.io cluster -o jsonpath='{.spec.plugins}'
+```
+
+Then reload the console: an **AutoShift** section appears in the Administrator sidebar.

--- a/policies/community/autoshift-console/README.md
+++ b/policies/community/autoshift-console/README.md
@@ -24,8 +24,36 @@ Plugin source lives in a separate repository: `auto-shift/autoshift-console-plug
 The `Console` patch uses `complianceType: musthave`, which **appends** to `spec.plugins`.
 `mustonlyhave` would evict every other console plugin on the cluster, including ACM's — do not change it.
 
-The two policies are split so the console is never pointed at a plugin whose Service does not exist
-yet: `policy-autoshift-console-enable` depends on `policy-autoshift-console`.
+`policy-autoshift-console-enable` depends on `policy-autoshift-console`, so the console is never
+pointed at a plugin whose Service does not exist yet.
+
+`policy-autoshift-console-available` is inform-only and reports when the plugin has no running pods.
+It exists because the other two cannot see that: policy 1 asserts the Deployment **object**, which a
+Deployment stuck in `ImagePullBackOff` still satisfies, and policy 2 deliberately goes quiet until
+pods are up. Without it a failed pull leaves every policy Compliant and the console simply empty.
+
+Compatibility is enforced by the image tag rather than a configured floor. The tag names the
+OpenShift minor it targets, so the policy derives it from the cluster's actual running version in
+`ClusterVersion` history, not the desired `openshift-version` label. A cluster therefore always
+pulls its own build, and a minor with no published build fails the pull instead of running a pod
+that renders nothing. Publishing a new tag is what makes a minor supported; there is no floor to
+keep in step with the plugin's `package.json`.
+
+The report is a Deployment that nothing creates, carrying only `metadata`; the wording comes from
+`customMessage`, not the object. Two properties of it are load-bearing, both verified on a live hub.
+It is **unconstructible**: a Deployment without `spec.selector` is rejected as invalid, so
+remediation cannot satisfy it and nothing is created. And it is **never produced by any policy**, so
+it cannot drift into existence.
+
+Both matter because the root `Policy` remediationAction overrides the child `ConfigurationPolicy`,
+which means one Enforce click in the console reaches this policy. Under that override a `mustnothave`
+sentinel on a cluster singleton such as `ClusterVersion` becomes a delete, and a `musthave` on a
+normal absent object becomes a create. Asserting a real resource does not work either: the plugin
+Deployment and its namespace both outlive the condition that produced them, because removing a
+policy removes nothing.
+
+One caveat this design accepts: a failed pull cannot distinguish an unpublished minor from an image
+that was never mirrored into a disconnected registry. The message names both.
 
 ## Placement
 
@@ -44,20 +72,27 @@ Hub-only, opt-in. The Placement requires **both**:
 
 ## Config
 
-Read from `config.autoshiftConsole` in the cluster's rendered-config ConfigMap. Both keys optional.
+Read from `config.autoshiftConsole` in the cluster's rendered-config ConfigMap. All keys optional.
 
 ```yaml
 hubClusterSets:
   hub:
     config:
       autoshiftConsole:
-        image: 'quay.io/autoshift/autoshift-console-plugin:ocp4.22'
+        repository: 'quay.io/autoshift/autoshift-console-plugin'
         replicas: 2
     labels:
       autoshift-console: 'true'
 ```
 
-Pin `image` to a released tag in production. In a disconnected environment the image is redirected by
+The tag is appended as `:ocp<minor>` from the cluster's running version, so `repository` is all most
+deployments set. A cluster whose minor has no published build fails the pull, so check which minors
+are tagged before enabling the label on a clusterset:
+[quay.io/autoshift/autoshift-console-plugin](https://quay.io/repository/autoshift/autoshift-console-plugin?tab=tags). An explicit `image` overrides both and is how a digest gets pinned, but it applies
+verbatim to every cluster the clusterset covers: pinning one tag across a fleet spanning minors
+deploys the wrong bundle to all but one of them. Pin per clusterset, or per cluster.
+
+In a disconnected environment the image is redirected by
 the cluster-wide `ImageDigestMirrorSet` the `disconnected-mirror` policy manages — no per-policy
 mirror suffix is involved, since this is a plain image rather than an OLM catalog source.
 

--- a/policies/community/autoshift-console/README.md
+++ b/policies/community/autoshift-console/README.md
@@ -1,8 +1,9 @@
 # AutoShift Console Plugin
 
 Deploys the AutoShift OpenShift console dynamic plugin — a read-only **AutoShift** section in the
-Administrator sidebar (Fleet / Cluster Sets / Clusters / Stacks) that surfaces AutoShift's clustersets,
-resolved configuration, label drift and version tracking.
+**Fleet management** perspective (Fleet / Cluster Sets / Clusters / Stacks) that surfaces AutoShift's
+clustersets, resolved configuration and OpenShift version tracking. It sits alongside Red Hat Advanced
+Cluster Management's own views, after Governance.
 
 Plugin source lives in a separate repository: `auto-shift/autoshift-console-plugin`.
 
@@ -80,4 +81,4 @@ oc get pods -n autoshift-console
 oc get console.operator.openshift.io cluster -o jsonpath='{.spec.plugins}'
 ```
 
-Then reload the console: an **AutoShift** section appears in the Administrator sidebar.
+Then reload the console: an **AutoShift** section appears in the **Fleet management** perspective.

--- a/policies/community/autoshift-console/kustomization.yaml
+++ b/policies/community/autoshift-console/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - policy-generator-config.yaml

--- a/policies/community/autoshift-console/manifests/autoshift-console.yaml
+++ b/policies/community/autoshift-console/manifests/autoshift-console.yaml
@@ -1,0 +1,171 @@
+object-templates-raw: |
+  {{- /* The console plugin bundles React 18 / PatternFly 6. OCP 4.20-4.21 consoles share React 17,
+         so the plugin is silently skipped there — the pod runs, serves assets, and nothing appears.
+         Gate on the ACTUAL running version (ClusterVersion history) rather than the desired
+         autoshift.io/openshift-version label, so a cluster mid-upgrade is judged on what it is
+         running now. Same semverCompare approach as the openshift-upgrade policy. */}}
+  {{- $minVersion := "{{hub- $cmv := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}{{hub- $cfgv := (index ($cmv | default dict) "data" | default dict) hub}}{{hub- $ymlv := (index $cfgv "config" | default "" | fromYaml | default dict) hub}}{{hub- $consolev := (index $ymlv "autoshiftConsole" | default dict) hub}}{{hub index $consolev "minOpenShiftVersion" | default "4.22.0-0" hub}}" }}
+  {{- $cvStatus := (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version" | default dict) "status" | default dict) }}
+  {{- $current := "" }}
+  {{- range $h := (index $cvStatus "history" | default list) }}
+  {{-   if and (eq $current "") (eq (index $h "state") "Completed") }}{{- $current = (index $h "version") }}{{- end }}
+  {{- end }}
+  {{- if and (ne $current "") (semverCompare (printf ">= %s" $minVersion) $current) }}
+  {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
+  {{hub- $config := (index ($cm | default dict) "data" | default dict) hub}}
+  {{hub- $configYaml := (index $config "config" | default "" | fromYaml | default dict) hub}}
+  {{hub- $console := (index $configYaml "autoshiftConsole" | default dict) hub}}
+  {{hub- $image := (index $console "image" | default "quay.io/autoshift/autoshift-console-plugin:ocp4.22") hub}}
+  {{hub- $replicas := (index $console "replicas" | default 2) hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: autoshift-console
+        labels:
+          # The plugin serves static assets only; it holds no workload that needs elevated SCCs.
+          pod-security.kubernetes.io/enforce: restricted
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: autoshift-console-nginx-conf
+        namespace: autoshift-console
+      data:
+        nginx.conf: |
+          error_log /dev/stdout info;
+          events {}
+          http {
+            include /etc/nginx/mime.types;
+            default_type application/octet-stream;
+            access_log /dev/stdout;
+            client_max_body_size 8m;
+            server {
+              listen 9443 ssl;
+              listen [::]:9443 ssl;
+              ssl_certificate /var/serving-cert/tls.crt;
+              ssl_certificate_key /var/serving-cert/tls.key;
+              root /usr/share/nginx/html;
+            }
+          }
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: autoshift-console
+        namespace: autoshift-console
+        labels:
+          app: autoshift-console
+          app.kubernetes.io/component: autoshift-console
+          app.kubernetes.io/name: autoshift-console
+          app.kubernetes.io/part-of: autoshift
+      spec:
+        replicas: {{hub $replicas hub}}
+        selector:
+          matchLabels:
+            app: autoshift-console
+        template:
+          metadata:
+            labels:
+              app: autoshift-console
+          spec:
+            containers:
+              - name: autoshift-console
+                image: {{hub $image hub}}
+                ports:
+                  - containerPort: 9443
+                    protocol: TCP
+                imagePullPolicy: Always
+                volumeMounts:
+                  - name: plugin-serving-cert
+                    readOnly: true
+                    mountPath: /var/serving-cert
+                  - name: nginx-conf
+                    readOnly: true
+                    mountPath: /etc/nginx/nginx.conf
+                    subPath: nginx.conf
+                # Keeps the Service endpoint-less until nginx is actually serving the bundle, which
+                # is what the console-enable readiness gate keys off.
+                readinessProbe:
+                  httpGet:
+                    path: /plugin-manifest.json
+                    port: 9443
+                    scheme: HTTPS
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 50Mi
+            volumes:
+              - name: plugin-serving-cert
+                secret:
+                  secretName: autoshift-console-cert
+                  defaultMode: 420
+              - name: nginx-conf
+                configMap:
+                  name: autoshift-console-nginx-conf
+                  defaultMode: 420
+            restartPolicy: Always
+            dnsPolicy: ClusterFirst
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: autoshift-console
+        namespace: autoshift-console
+        labels:
+          app: autoshift-console
+          app.kubernetes.io/component: autoshift-console
+          app.kubernetes.io/name: autoshift-console
+          app.kubernetes.io/part-of: autoshift
+        annotations:
+          # service-ca mints the TLS cert the nginx listener above serves.
+          service.beta.openshift.io/serving-cert-secret-name: autoshift-console-cert
+      spec:
+        ports:
+          - name: 9443-tcp
+            protocol: TCP
+            port: 9443
+            targetPort: 9443
+        selector:
+          app: autoshift-console
+        type: ClusterIP
+        sessionAffinity: None
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: console.openshift.io/v1
+      kind: ConsolePlugin
+      metadata:
+        name: autoshift-console
+      spec:
+        displayName: AutoShift
+        backend:
+          type: Service
+          service:
+            name: autoshift-console
+            namespace: autoshift-console
+            port: 9443
+            basePath: /
+        # The i18n namespace in the plugin source (plugin__autoshift-console) must match this
+        # resource's name, or translated labels in console-extensions.json resolve to raw keys.
+        #
+        # Lazy, not Preload: Preload makes the console fetch this plugin's locale bundle during
+        # bootstrap of every page. If the plugin is unreachable that cost — and its failure — is
+        # paid across the whole console rather than only on the AutoShift routes.
+        i18n:
+          loadType: Lazy
+  {{- end }}

--- a/policies/community/autoshift-console/manifests/autoshift-console.yaml
+++ b/policies/community/autoshift-console/manifests/autoshift-console.yaml
@@ -1,21 +1,25 @@
 object-templates-raw: |
-  {{- /* The console plugin bundles React 18 / PatternFly 6. OCP 4.20-4.21 consoles share React 17,
-         so the plugin is silently skipped there — the pod runs, serves assets, and nothing appears.
-         Gate on the ACTUAL running version (ClusterVersion history) rather than the desired
-         autoshift.io/openshift-version label, so a cluster mid-upgrade is judged on what it is
-         running now. Same semverCompare approach as the openshift-upgrade policy. */}}
-  {{- $minVersion := "{{hub- $cmv := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}{{hub- $cfgv := (index ($cmv | default dict) "data" | default dict) hub}}{{hub- $ymlv := (index $cfgv "config" | default "" | fromYaml | default dict) hub}}{{hub- $consolev := (index $ymlv "autoshiftConsole" | default dict) hub}}{{hub index $consolev "minOpenShiftVersion" | default "4.22.0-0" hub}}" }}
+  {{- /* The tag names the OpenShift minor it targets, so it comes from the ACTUAL running version
+         (ClusterVersion history), not the desired autoshift.io/openshift-version label. A minor
+         with no published build has no tag; policy-autoshift-console-available reports the
+         failed pull. */}}
   {{- $cvStatus := (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version" | default dict) "status" | default dict) }}
   {{- $current := "" }}
   {{- range $h := (index $cvStatus "history" | default list) }}
   {{-   if and (eq $current "") (eq (index $h "state") "Completed") }}{{- $current = (index $h "version") }}{{- end }}
   {{- end }}
-  {{- if and (ne $current "") (semverCompare (printf ">= %s" $minVersion) $current) }}
+  {{- if ne $current "" }}
   {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
   {{hub- $config := (index ($cm | default dict) "data" | default dict) hub}}
   {{hub- $configYaml := (index $config "config" | default "" | fromYaml | default dict) hub}}
   {{hub- $console := (index $configYaml "autoshiftConsole" | default dict) hub}}
-  {{hub- $image := (index $console "image" | default "quay.io/autoshift/autoshift-console-plugin:ocp4.22") hub}}
+  {{hub- $repository := (index $console "repository" | default "quay.io/autoshift/autoshift-console-plugin") hub}}
+  {{hub- $imageOverride := (index $console "image" | default "") hub}}
+  {{- /* An explicit config.autoshiftConsole.image wins, so a digest can be pinned in production. */ -}}
+  {{- $image := "{{hub $imageOverride hub}}" }}
+  {{- if eq $image "" }}
+  {{-   $image = printf "%s:ocp%s" "{{hub $repository hub}}" (regexFind "^[0-9]+[.][0-9]+" $current) }}
+  {{- end }}
   {{hub- $replicas := (index $console "replicas" | default 2) hub}}
   - complianceType: musthave
     objectDefinition:
@@ -74,7 +78,7 @@ object-templates-raw: |
           spec:
             containers:
               - name: autoshift-console
-                image: {{hub $image hub}}
+                image: {{ $image }}
                 ports:
                   - containerPort: 9443
                     protocol: TCP

--- a/policies/community/autoshift-console/manifests/console-enable.yaml
+++ b/policies/community/autoshift-console/manifests/console-enable.yaml
@@ -1,25 +1,14 @@
 object-templates-raw: |
-  {{- /* The console plugin bundles React 18 / PatternFly 6. OCP 4.20-4.21 consoles share React 17,
-         so the plugin is silently skipped there — the pod runs, serves assets, and nothing appears.
-         Gate on the ACTUAL running version (ClusterVersion history) rather than the desired
-         autoshift.io/openshift-version label, so a cluster mid-upgrade is judged on what it is
-         running now. Same semverCompare approach as the openshift-upgrade policy. */}}
-  {{- $minVersion := "{{hub- $cmv := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}{{hub- $cfgv := (index ($cmv | default dict) "data" | default dict) hub}}{{hub- $ymlv := (index $cfgv "config" | default "" | fromYaml | default dict) hub}}{{hub- $consolev := (index $ymlv "autoshiftConsole" | default dict) hub}}{{hub index $consolev "minOpenShiftVersion" | default "4.22.0-0" hub}}" }}
-  {{- $cvStatus := (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version" | default dict) "status" | default dict) }}
-  {{- $current := "" }}
-  {{- range $h := (index $cvStatus "history" | default list) }}
-  {{-   if and (eq $current "") (eq (index $h "state") "Completed") }}{{- $current = (index $h "version") }}{{- end }}
-  {{- end }}
   {{- /* Readiness gate. The Policy dependency on policy-autoshift-console only proves the
          Deployment OBJECT exists — a Deployment stuck in ImagePullBackOff is still Compliant, and
          enabling a plugin whose Service has no endpoints degrades EVERY console page, not just the
          AutoShift routes, because the console fetches each enabled plugin's manifest at bootstrap.
-         So gate on availableReplicas instead. Until then this policy emits nothing and is
-         trivially compliant. */}}
+         So gate on availableReplicas instead. Until then this policy emits nothing;
+         policy-autoshift-console-available is what reports the wait. */}}
   {{- $deploy := (lookup "apps/v1" "Deployment" "autoshift-console" "autoshift-console" | default dict) }}
   {{- $deployStatus := (index ($deploy | default dict) "status" | default dict) }}
   {{- $available := (index $deployStatus "availableReplicas" | default 0 | int) }}
-  {{- if and (ne $current "") (semverCompare (printf ">= %s" $minVersion) $current) (gt $available 0) }}
+  {{- if gt $available 0 }}
   {{/* musthave on spec.plugins APPENDS to the list. mustonlyhave would evict every other
        console plugin on the cluster, including ACM's — never change this complianceType. */}}
   - complianceType: musthave

--- a/policies/community/autoshift-console/manifests/console-enable.yaml
+++ b/policies/community/autoshift-console/manifests/console-enable.yaml
@@ -1,0 +1,34 @@
+object-templates-raw: |
+  {{- /* The console plugin bundles React 18 / PatternFly 6. OCP 4.20-4.21 consoles share React 17,
+         so the plugin is silently skipped there — the pod runs, serves assets, and nothing appears.
+         Gate on the ACTUAL running version (ClusterVersion history) rather than the desired
+         autoshift.io/openshift-version label, so a cluster mid-upgrade is judged on what it is
+         running now. Same semverCompare approach as the openshift-upgrade policy. */}}
+  {{- $minVersion := "{{hub- $cmv := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}{{hub- $cfgv := (index ($cmv | default dict) "data" | default dict) hub}}{{hub- $ymlv := (index $cfgv "config" | default "" | fromYaml | default dict) hub}}{{hub- $consolev := (index $ymlv "autoshiftConsole" | default dict) hub}}{{hub index $consolev "minOpenShiftVersion" | default "4.22.0-0" hub}}" }}
+  {{- $cvStatus := (index (lookup "config.openshift.io/v1" "ClusterVersion" "" "version" | default dict) "status" | default dict) }}
+  {{- $current := "" }}
+  {{- range $h := (index $cvStatus "history" | default list) }}
+  {{-   if and (eq $current "") (eq (index $h "state") "Completed") }}{{- $current = (index $h "version") }}{{- end }}
+  {{- end }}
+  {{- /* Readiness gate. The Policy dependency on policy-autoshift-console only proves the
+         Deployment OBJECT exists — a Deployment stuck in ImagePullBackOff is still Compliant, and
+         enabling a plugin whose Service has no endpoints degrades EVERY console page, not just the
+         AutoShift routes, because the console fetches each enabled plugin's manifest at bootstrap.
+         So gate on availableReplicas instead. Until then this policy emits nothing and is
+         trivially compliant. */}}
+  {{- $deploy := (lookup "apps/v1" "Deployment" "autoshift-console" "autoshift-console" | default dict) }}
+  {{- $deployStatus := (index ($deploy | default dict) "status" | default dict) }}
+  {{- $available := (index $deployStatus "availableReplicas" | default 0 | int) }}
+  {{- if and (ne $current "") (semverCompare (printf ">= %s" $minVersion) $current) (gt $available 0) }}
+  {{/* musthave on spec.plugins APPENDS to the list. mustonlyhave would evict every other
+       console plugin on the cluster, including ACM's — never change this complianceType. */}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: operator.openshift.io/v1
+      kind: Console
+      metadata:
+        name: cluster
+      spec:
+        plugins:
+          - autoshift-console
+  {{- end }}

--- a/policies/community/autoshift-console/placement.yaml
+++ b/policies/community/autoshift-console/placement.yaml
@@ -1,0 +1,27 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-autoshift-console
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  # No spec.clusterSets: selects across all ManagedClusterSetBindings in this namespace,
+  # filtered by the predicate below.
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            # Hub-only: the plugin reads the cluster-labels / cluster-config / rendered-config
+            # ConfigMaps, which only exist where an AutoShift instance runs (incl. spoke hubs).
+            - key: 'autoshift.io/cluster-type'
+              operator: In
+              values:
+                - 'hub'
+            - key: 'autoshift.io/autoshift-console'
+              operator: In
+              values:
+                - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/community/autoshift-console/policy-generator-config.yaml
+++ b/policies/community/autoshift-console/policy-generator-config.yaml
@@ -44,3 +44,16 @@ policies:
       - name: policy-autoshift-console
     manifests:
       - path: manifests/console-enable.yaml
+  # 3) Availability (inform) — reports when the plugin has no running pods; (1) is satisfied by the
+  #    Deployment object alone and (2) goes quiet until pods are up.
+  - name: policy-autoshift-console-available
+    remediationAction: inform
+    manifests:
+      - path: test/autoshift-console-available.yaml
+    customMessage:
+      noncompliant: >-
+        AutoShift console plugin has no available pods. The image tag is derived from this cluster's
+        OpenShift minor, so the usual causes are that no plugin build is published for that minor,
+        or that the image is not mirrored in a disconnected environment. Check the Deployment and
+        pod events in the autoshift-console namespace, or set autoshift.io/autoshift-console to
+        'false' to stop requesting the plugin. This is expected briefly while pods roll out.

--- a/policies/community/autoshift-console/policy-generator-config.yaml
+++ b/policies/community/autoshift-console/policy-generator-config.yaml
@@ -1,0 +1,46 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: autoshift-console
+# Per-deployment scalars (${...}) are substituted by the repo-server CMP (envsubst/sed) BEFORE
+# `kustomize build` runs. They live here and in placement.yaml — never in manifests/, whose hub
+# templates contain `$vars` that substitution would clobber.
+#
+# Each policy references a single bare manifest file (manifests/<policy>.yaml). Add another policy
+# by dropping manifests/<name>.yaml + a policies[] entry here (re-run generate-policy.sh --dir <this>).
+# Both policies share placement.yaml, so the PlacementBinding needs an explicit name.
+placementBindingDefaults:
+  name: binding-policy-autoshift-console
+policyDefaults:
+  namespace: ${POLICY_NAMESPACE}
+  # ${REMEDIATION} = inform when autoshift.dryRun, else enforce.
+  remediationAction: ${REMEDIATION}
+  severity: medium
+  consolidateManifests: true
+  evaluationInterval:
+    compliant: ${EVAL_COMPLIANT}
+    noncompliant: ${EVAL_NONCOMPLIANT}
+  standards:
+    - NIST SP 800-53
+  categories:
+    - CM Configuration Management
+  controls:
+    - CM-2 Baseline Configuration
+  # Default Placement (placement.yaml at the dir root); policies with a different predicate set
+  # their own placement.placementPath. PG includes it and generates only the PlacementBinding.
+  placement:
+    placementPath: placement.yaml
+policies:
+  # 1) The plugin itself: namespace, nginx config, Deployment, Service (service-ca TLS) and the
+  #    ConsolePlugin registration. Image/replicas come from config.autoshiftConsole in rendered-config.
+  - name: policy-autoshift-console
+    manifests:
+      - path: manifests/autoshift-console.yaml
+  # 2) Enable the plugin in the console operator. Split out so (1) is applied first; the manifest
+  #    itself waits on the Deployment reporting availableReplicas, because this dependency only
+  #    proves (1) is Compliant — a Deployment in ImagePullBackOff satisfies that.
+  - name: policy-autoshift-console-enable
+    dependencies:
+      - name: policy-autoshift-console
+    manifests:
+      - path: manifests/console-enable.yaml

--- a/policies/community/autoshift-console/test/autoshift-console-available.yaml
+++ b/policies/community/autoshift-console/test/autoshift-console-available.yaml
@@ -1,0 +1,17 @@
+object-templates-raw: |
+  {{- /* Reports when the plugin has no running pods: the deploy policy is satisfied by the
+         Deployment object alone, which a failed image pull still creates, and the enable policy
+         stays quiet until pods are up. */}}
+  {{- $deploy := (lookup "apps/v1" "Deployment" "autoshift-console" "autoshift-console" | default dict) }}
+  {{- $available := (index ($deploy | default dict) "status" | default dict) }}
+  {{- /* Nothing creates this Deployment, and metadata alone is invalid, so an enforce override
+         cannot satisfy or create it. */ -}}
+  {{- if lt (index $available "availableReplicas" | default 0 | int) 1 }}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: autoshift-console-no-available-replicas
+        namespace: autoshift-console
+  {{- end }}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] New policy (new operator or cluster configuration)
- [ ] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [ ] Other: <!-- describe -->

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
