### PR TITLE
Feature/ocp 4.22

### DIFF
--- a/autoshift/values/clusters/_example-cluster-install-aws.yaml
+++ b/autoshift/values/clusters/_example-cluster-install-aws.yaml
@@ -58,7 +58,7 @@ clusters:
         createCluster: 'true'
         platform: aws
         baseDomain: example.com                      # optional: if empty/omitted, inherits the hub's base domain (hub DNS baseDomain minus the cluster-name label)
-        openshiftVersion: '4.20.16'
+        openshiftVersion: '4.22.8'
         # cpuArch: x86_64                           # default: x86_64
         openshiftChannel: stable                     # ClusterImageSet channel label
         # clusterImageSet: ''                        # optional, overrides openshiftVersion

--- a/autoshift/values/clusters/_example-cluster-install-baremetal.yaml
+++ b/autoshift/values/clusters/_example-cluster-install-baremetal.yaml
@@ -220,7 +220,7 @@ clusters:
       #       publisher: Red Hat
       #       displayName: 'Red Hat Marketplace (Mirrored)'
       #   osImages:                                  # RHCOS images for hub AgentServiceConfig
-      #     - openshiftVersion: '4.20'               # Major.Minor
+      #     - openshiftVersion: '4.22'               # Major.Minor
       #       version: '420.86.202301311551-0'        # RHCOS version string
       #       cpuArchitecture: x86_64
       #       url: 'https://mirror.example.com/rhcos/rhcos-live.x86_64.iso'
@@ -252,7 +252,7 @@ clusters:
         createCluster: 'true'                       # Required — triggers provisioning
         platform: baremetal                          # 'baremetal', 'aws', or 'vmware'
         baseDomain: example.com
-        openshiftVersion: '4.20.29'
+        openshiftVersion: '4.22.8'
         cpuArch: x86_64                             # default: x86_64
         openshiftChannel: stable                    # ClusterImageSet channel label (default: stable)
         # clusterImageSet: ''                       # optional, overrides openshiftVersion+cpuArch

--- a/autoshift/values/clusters/_example-cluster-install-vmware-static.yaml
+++ b/autoshift/values/clusters/_example-cluster-install-vmware-static.yaml
@@ -45,7 +45,7 @@ clusters:
         createCluster: 'true'
         platform: vmware
         baseDomain: example.com
-        openshiftVersion: '4.20.16'
+        openshiftVersion: '4.22.8'
         openshiftChannel: stable
         pullSecretRef:
           name: 'vsphere-creds'

--- a/autoshift/values/clusters/_example-cluster-install-vmware.yaml
+++ b/autoshift/values/clusters/_example-cluster-install-vmware.yaml
@@ -59,7 +59,7 @@ clusters:
         createCluster: 'true'
         platform: vmware
         baseDomain: example.com
-        openshiftVersion: '4.20.16'
+        openshiftVersion: '4.22.8'
         # cpuArch: x86_64                           # default: x86_64
         openshiftChannel: stable                     # ClusterImageSet channel label
         # clusterImageSet: ''                        # optional, overrides openshiftVersion

--- a/autoshift/values/clusters/_example.yaml
+++ b/autoshift/values/clusters/_example.yaml
@@ -89,7 +89,7 @@ clusters:
       # =======================================================================
       # Core Configuration
       # =======================================================================
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
 
       # =======================================================================
       # Operator Toggles
@@ -127,12 +127,12 @@ clusters:
       tempo-version: 'tempo-operator.v0.19.0-3'
       kiali-version: 'kiali-operator.v2.17.3'
       servicemesh3operator-version: 'servicemeshoperator3.v3.3.1'
-      metallb-version: 'metallb-operator.v4.20.0-202602021426'
+      metallb-version: 'metallb-operator.v4.22.0-202607272042'
       aap-version: 'aap-operator.v2.6.0-0.1768951413'
-      lvm-version: 'lvms-operator.v4.20.0'
-      local-storage-version: 'local-storage-operator.v4.20.0-202602032049'
-      odf-version: 'odf-operator.v4.20.5-rhodf'
-      nmstate-version: 'kubernetes-nmstate-operator.4.20.0-202601292039'
+      lvm-version: 'lvms-operator.v4.22.0'
+      local-storage-version: 'local-storage-operator.v4.22.0-202607272042'
+      odf-version: 'odf-operator.v4.22.1-rhodf'
+      nmstate-version: 'kubernetes-nmstate-operator.4.22.0-202607280824'
       acs-version: 'rhacs-operator.v4.9.2'
       dev-spaces-version: 'devspacesoperator.v3.26.0'
       dev-hub-version: 'rhdh-operator.v1.8.3'
@@ -143,16 +143,16 @@ clusters:
       logging-version: 'cluster-logging.v6.4.2'
       coo-version: 'cluster-observability-operator.v1.3.1'
       compliance-version: 'compliance-operator.v1.8.2'
-      virt-version: 'kubevirt-hyperconverged-operator.v4.20.6'
+      virt-version: 'kubevirt-hyperconverged-operator.v4.22.2'
       mtv-version: 'mtv-operator.v2.9.6'
-      node-feature-discovery-version: 'nfd.4.20.0-202601292039'
+      node-feature-discovery-version: 'nfd.4.22.0-202607272042'
 
       # =======================================================================
       # Channel Overrides
       # =======================================================================
       gitops-channel: gitops-1.21
       acs-channel: stable
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       pipelines-channel: pipelines-1.23
       acm-channel: release-2.17
 

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -129,9 +129,9 @@ hubClusterSets:
               mirror: 'registry.example.com:5000/hashicorp'
         catalogs:
           - source: redhat-operators
-            image: 'registry.example.com:5000/redhat/redhat-operator-index:v4.20'
+            image: 'registry.example.com:5000/redhat/redhat-operator-index:v4.22'
           - source: certified-operators
-            image: 'registry.example.com:5000/redhat/certified-operator-index:v4.20'
+            image: 'registry.example.com:5000/redhat/certified-operator-index:v4.22'
         useIDMS: true
         disableDefaultCatalogs: true
       # =======================================================================
@@ -503,7 +503,7 @@ hubClusterSets:
       # DERIVED — do not set: cluster-type ('hub' for hubClusterSets entries, 'spoke' for
       # managedClusterSets entries). Injected by the top-level chart, so a value set here is
       # overwritten. A self-managed hub is cluster-type 'hub' plus self-managed 'true'.
-      openshift-version: '4.20.29'       # desired OCP version: operator-catalog alignment (tooling) + upgrade target (openshift-upgrade policy)
+      openshift-version: '4.22.8'       # desired OCP version: operator-catalog alignment (tooling) + upgrade target (openshift-upgrade policy)
       policy-namespace: ''               # hub only — overrides the ACM policy namespace
 
       # =======================================================================
@@ -513,7 +513,7 @@ hubClusterSets:
       # controlled by clusterset membership — roll out in waves; never enable on a populated clusterset.
       # =======================================================================
       openshift-upgrade: 'false'                    # opt cluster in to Day-2 platform upgrades
-      openshift-upgrade-channel: 'stable-4.20'      # ClusterVersion channel
+      openshift-upgrade-channel: 'stable-4.22'      # ClusterVersion channel
       openshift-upgrade-upstream: 'https://api.openshift.com/api/upgrades_info/v1/graph'  # OSUS graph (local URL when disconnected)
 
       # =======================================================================
@@ -607,7 +607,7 @@ hubClusterSets:
       # =======================================================================
       metallb: 'false'
       metallb-subscription-name: metallb-operator
-      metallb-version: 'metallb-operator.v4.20.0-202602021426'
+      metallb-version: 'metallb-operator.v4.22.0-202607272042'
       metallb-source: redhat-operators
       metallb-source-namespace: openshift-marketplace
       metallb-channel: stable
@@ -733,12 +733,12 @@ hubClusterSets:
       # =======================================================================
       lvm: 'false'
       lvm-subscription-name: lvms-operator
-      lvm-version: 'lvms-operator.v4.20.0'
+      lvm-version: 'lvms-operator.v4.22.0'
       lvm-default: 'true'                   # Set as default StorageClass
       lvm-fstype: xfs                        # 'xfs' or 'ext4'
       lvm-size-percent: 90                   # Percentage of VG for thinpool
       lvm-overprovision-ratio: 10
-      lvm-channel: stable-4.20
+      lvm-channel: stable-4.22
       lvm-source: redhat-operators
       lvm-source-namespace: openshift-marketplace
 
@@ -747,7 +747,7 @@ hubClusterSets:
       # =======================================================================
       local-storage: 'false'
       local-storage-subscription-name: local-storage-operator
-      local-storage-version: 'local-storage-operator.v4.20.0-202602032049'
+      local-storage-version: 'local-storage-operator.v4.22.0-202607272042'
       local-storage-channel: stable
       local-storage-source: redhat-operators
       local-storage-source-namespace: openshift-marketplace
@@ -757,7 +757,7 @@ hubClusterSets:
       # =======================================================================
       odf: 'false'
       odf-subscription-name: odf-operator
-      odf-version: 'odf-operator.v4.20.5-rhodf'
+      odf-version: 'odf-operator.v4.22.1-rhodf'
       odf-multi-cloud-gateway: standalone    # 'standalone' (noobaa only) or 'standard' (full ODF)
       odf-noobaa-pvpool: ''                  # Use PV pool for noobaa backing store
       odf-noobaa-store-size: ''              # e.g., '500Gi' - size of noobaa backing store
@@ -770,7 +770,7 @@ hubClusterSets:
       odf-resource-profile: balanced         # 'lean', 'balanced', or 'performance'
       odf-default-storageclass: 'ocs-storagecluster-ceph-rbd'  # Sets as default StorageClass
       odf-csi-all-nodes: 'false'            # 'true' to run CSI plugins on all nodes (masters, infra, storage)
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
 
@@ -796,7 +796,7 @@ hubClusterSets:
       nmstate-channel: stable
       nmstate-source: redhat-operators
       nmstate-source-namespace: openshift-marketplace
-      nmstate-version: 'kubernetes-nmstate-operator.4.20.0-202601292039'
+      nmstate-version: 'kubernetes-nmstate-operator.4.22.0-202607280824'
       #
       # =======================================================================
       # Advanced Cluster Security
@@ -949,7 +949,7 @@ hubClusterSets:
       virt: 'false'
       virt-subscription-name: kubevirt-hyperconverged
       virt-channel: stable
-      virt-version: 'kubevirt-hyperconverged-operator.v4.20.6'
+      virt-version: 'kubevirt-hyperconverged-operator.v4.22.2'
       virt-source: redhat-operators
       virt-source-namespace: openshift-marketplace
 
@@ -971,7 +971,7 @@ hubClusterSets:
       node-feature-discovery-channel: stable
       node-feature-discovery-source: redhat-operators
       node-feature-discovery-source-namespace: openshift-marketplace
-      node-feature-discovery-version: 'nfd.4.20.0-202601292039'
+      node-feature-discovery-version: 'nfd.4.22.0-202607272042'
 
       # =======================================================================
       # SR-IOV Network Operator

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -856,7 +856,7 @@ hubClusterSets:
       quay: 'false'
       quay-subscription-name: quay-operator
       quay-version: 'quay-operator.v3.8.15'
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
 
@@ -958,7 +958,7 @@ hubClusterSets:
       # =======================================================================
       mtv: 'false'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.9
+      mtv-channel: release-v2.12
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub-ambient.yaml
+++ b/autoshift/values/clustersets/hub-ambient.yaml
@@ -9,7 +9,7 @@ hubClusterSets:
   hub:
     labels:
       # Required: OpenShift version for image mirroring and compatibility
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
 
       # Required: Indicates this is a self-managed hub cluster
       self-managed: 'true'
@@ -82,7 +82,7 @@ hubClusterSets:
       ### OpenShift Data Foundation — provides NooBaa OBC storage for TempoStack
       odf: 'true'
       odf-subscription-name: odf-operator
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       odf-multi-cloud-gateway: standard

--- a/autoshift/values/clustersets/hub-baremetal-compact.yaml
+++ b/autoshift/values/clustersets/hub-baremetal-compact.yaml
@@ -12,7 +12,7 @@ hubClusterSets:
   hub:
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       self-managed: 'true'
       ### Advance Cluster Manager
       acm-subscription-name: advanced-cluster-management
@@ -101,7 +101,7 @@ hubClusterSets:
       lvm-fstype: xfs
       lvm-size-percent: 90
       lvm-overprovision-ratio: 10
-      lvm-channel: stable-4.20
+      lvm-channel: stable-4.22
       lvm-source: redhat-operators
       lvm-source-namespace: openshift-marketplace
       ### Local Storage Operator
@@ -123,7 +123,7 @@ hubClusterSets:
       odf-ocs-storage-replicas: '1' # Flexible Scaling uses replica 1 and count is the total of all your drives/OSDs
       odf-ocs-flexible-scaling: 'true'
       odf-resource-profile: 'lean'
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       # ### OpenShift Internal Registry
@@ -237,7 +237,7 @@ hubClusterSets:
       ### Quay
       quay: 'false'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-install-plan-approval: Automatic
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
@@ -278,7 +278,7 @@ hubClusterSets:
       ### Migration Toolkit for Openshift Virtualization
       mtv: 'true'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.10
+      mtv-channel: release-v2.11
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub-baremetal-compact.yaml
+++ b/autoshift/values/clustersets/hub-baremetal-compact.yaml
@@ -278,7 +278,7 @@ hubClusterSets:
       ### Migration Toolkit for Openshift Virtualization
       mtv: 'true'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.11
+      mtv-channel: release-v2.12
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub-baremetal-sno.yaml
+++ b/autoshift/values/clustersets/hub-baremetal-sno.yaml
@@ -12,7 +12,7 @@ hubClusterSets:
   hub:
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       self-managed: 'true'
       ### Advance Cluster Manager
       acm-subscription-name: advanced-cluster-management
@@ -154,7 +154,7 @@ hubClusterSets:
       lvm-fstype: xfs
       lvm-size-percent: 90
       lvm-overprovision-ratio: 10
-      lvm-channel: stable-4.20
+      lvm-channel: stable-4.22
       lvm-source: redhat-operators
       lvm-source-namespace: openshift-marketplace
       ### Local Storage Operator
@@ -175,7 +175,7 @@ hubClusterSets:
       # odf-ocs-storage-count: ''
       # odf-ocs-storage-replicas: ''
       # odf-resource-profile: ''
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       ### OpenShift Internal Registry
@@ -222,7 +222,7 @@ hubClusterSets:
       ### Quay
       quay: 'false'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-install-plan-approval: Automatic
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
@@ -261,7 +261,7 @@ hubClusterSets:
       ### Migration Toolkit for Openshift Virtualization
       mtv: 'true'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.10
+      mtv-channel: release-v2.11
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub-baremetal-sno.yaml
+++ b/autoshift/values/clustersets/hub-baremetal-sno.yaml
@@ -261,7 +261,7 @@ hubClusterSets:
       ### Migration Toolkit for Openshift Virtualization
       mtv: 'true'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.11
+      mtv-channel: release-v2.12
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub-minimal.yaml
+++ b/autoshift/values/clustersets/hub-minimal.yaml
@@ -21,7 +21,7 @@ hubClusterSets:
   hub:
     labels:
       # Required: OpenShift version for image mirroring and compatibility
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
 
       # Required: Indicates this is a self-managed hub cluster
       self-managed: 'true'

--- a/autoshift/values/clustersets/hub.yaml
+++ b/autoshift/values/clustersets/hub.yaml
@@ -53,7 +53,7 @@ hubClusterSets:
           enabled: true
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       self-managed: 'true'
       ### OpenShift Gitops
       gitops: 'true' # is expected to be installed on all hub clusters
@@ -243,7 +243,7 @@ hubClusterSets:
       lvm-fstype: xfs
       lvm-size-percent: 90
       lvm-overprovision-ratio: 10
-      lvm-channel: stable-4.20
+      lvm-channel: stable-4.22
       lvm-source: redhat-operators
       lvm-source-namespace: openshift-marketplace
       ### Local Storage Operator
@@ -266,7 +266,7 @@ hubClusterSets:
       odf-ocs-storage-count: '2'
       odf-ocs-storage-replicas: '3'
       odf-resource-profile: balanced
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       odf-default-storageclass: ocs-storagecluster-ceph-rbd
@@ -326,7 +326,7 @@ hubClusterSets:
       quay: 'true'
       quay-subscription-name: quay-operator
       # quay-version: 'quay-operator.v3.15.0'
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
       ### Developer OpenShift Gitops
@@ -381,7 +381,7 @@ hubClusterSets:
       ### Migration Toolkit for Openshift Virtualization
       mtv: 'false'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.10
+      mtv-channel: release-v2.11
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       # mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub.yaml
+++ b/autoshift/values/clustersets/hub.yaml
@@ -381,7 +381,7 @@ hubClusterSets:
       ### Migration Toolkit for Openshift Virtualization
       mtv: 'false'
       mtv-subscription-name: mtv-operator
-      mtv-channel: release-v2.11
+      mtv-channel: release-v2.12
       mtv-source: redhat-operators
       mtv-source-namespace: openshift-marketplace
       # mtv-version: 'mtv-operator.v2.9.6'

--- a/autoshift/values/clustersets/hub1.yaml
+++ b/autoshift/values/clustersets/hub1.yaml
@@ -4,7 +4,7 @@ hubClusterSets:
     config: {}
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       gitops: 'true' # is expected to be installed on all hub clusters
       gitops-subscription-name: openshift-gitops-operator
       gitops-disable-default-argocd: 'true'
@@ -47,7 +47,7 @@ hubClusterSets:
       odf-ocs-storage-count: ''
       odf-ocs-storage-replicas: ''
       odf-resource-profile: balanced
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       ### Kubernetes NMState Operator
@@ -90,7 +90,7 @@ hubClusterSets:
       ### Quay
       quay: 'true'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
       ### Developer OpenShift Gitops

--- a/autoshift/values/clustersets/hub2.yaml
+++ b/autoshift/values/clustersets/hub2.yaml
@@ -3,7 +3,7 @@ hubClusterSets:
   hub2:
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       gitops: 'true' # is expected to be installed on all hub clusters
       gitops-subscription-name: openshift-gitops-operator
       gitops-disable-default-argocd: 'true'
@@ -42,7 +42,7 @@ hubClusterSets:
       odf-ocs-storage-count: ''
       odf-ocs-storage-replicas: ''
       odf-resource-profile: balanced
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       ### Kubernetes NMState Operator
@@ -85,7 +85,7 @@ hubClusterSets:
       ### Quay
       quay: 'true'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
       ### Developer OpenShift Gitops

--- a/autoshift/values/clustersets/hubofhubs.yaml
+++ b/autoshift/values/clustersets/hubofhubs.yaml
@@ -7,7 +7,7 @@ hubClusterSets:
     config: {}
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       self-managed: 'true'
       ### OpenShift Gitops
       gitops: 'true' # is expected to be installed on all hub clusters
@@ -61,7 +61,7 @@ hubClusterSets:
       odf-ocs-storage-count: ''
       odf-ocs-storage-replicas: ''
       odf-resource-profile: balanced
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       ### OpenShift Internal Registry
@@ -115,7 +115,7 @@ hubClusterSets:
       ### Quay
       quay: 'false'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: redhat-operators
       quay-source-namespace: openshift-marketplace
       ### Developer OpenShift Gitops

--- a/autoshift/values/clustersets/managed.yaml
+++ b/autoshift/values/clustersets/managed.yaml
@@ -15,7 +15,7 @@ managedClusterSets:
           storage: '10Gi'
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       ### tempo
       tempo: 'true'
       tempo-subscription-name: tempo-product
@@ -93,7 +93,7 @@ managedClusterSets:
       odf-ocs-storage-count: ''
       odf-ocs-storage-replicas: ''
       odf-resource-profile: balanced
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       # odf-default-storageclass: gp3-csi
@@ -131,7 +131,7 @@ managedClusterSets:
       ### Quay
       quay: 'false'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: '' # redhat-operators
       quay-source-namespace: '' # openshift-marketplace
       ### Developer OpenShift Gitops

--- a/autoshift/values/clustersets/sbx.yaml
+++ b/autoshift/values/clustersets/sbx.yaml
@@ -3,7 +3,7 @@ managedClusterSets:
   sbx:
     labels:
       # OpenShift version for cluster deployment and image mirroring
-      openshift-version: '4.20.29'
+      openshift-version: '4.22.8'
       ### infra-nodes
       infra-nodes: ''
       infra-nodes-numcpu: ''
@@ -74,7 +74,7 @@ managedClusterSets:
       odf-ocs-storage-count: ''
       odf-ocs-storage-replicas: ''
       odf-resource-profile: balanced
-      odf-channel: stable-4.20
+      odf-channel: stable-4.22
       odf-source: redhat-operators
       odf-source-namespace: openshift-marketplace
       ### OpenShift Internal Registry
@@ -128,7 +128,7 @@ managedClusterSets:
       ### Quay
       quay: 'false'
       quay-subscription-name: quay-operator
-      quay-channel: stable-3.17
+      quay-channel: stable-3.18
       quay-source: '' # redhat-operators
       quay-source-namespace: '' # openshift-marketplace
       ### Developer OpenShift Gitops
@@ -193,7 +193,7 @@ managedClusterSets:
       # metallb-peer-1: ''
       ### LVM Operator
       # lvm: 'false'
-      # lvm-channel: stable-4.20
+      # lvm-channel: stable-4.22
       # lvm-source: redhat-operators
       # lvm-source-namespace: openshift-marketplace
       # lvm-default: 'true'

--- a/policies/stable/lvm/manifests/operator-install/kustomization.yaml
+++ b/policies/stable/lvm/manifests/operator-install/kustomization.yaml
@@ -14,7 +14,7 @@ helmCharts:
       remediation: ${REMEDIATION}
       subscription:
         name: '{{hub index .ManagedClusterLabels "autoshift.io/lvm-subscription-name" | default "lvms-operator" hub}}'
-        channel: '{{hub index .ManagedClusterLabels "autoshift.io/lvm-channel" | default "stable-4.20" hub}}'
+        channel: '{{hub index .ManagedClusterLabels "autoshift.io/lvm-channel" | default "stable-4.22" hub}}'
         source: '{{hub $base := (index .ManagedClusterLabels "autoshift.io/lvm-source" | default "redhat-operators") hub}}{{hub ternary (printf "%s-%s" $base (index .ManagedClusterLabels "autoshift.io/mirror-catalog-suffix" | default "mirror")) $base (eq (index .ManagedClusterLabels "autoshift.io/disconnected-mirror" | default "false") "true") hub}}'
         sourceNamespace: '{{hub index .ManagedClusterLabels "autoshift.io/lvm-source-namespace" | default "openshift-marketplace" hub}}'
         # Version resolution (config lives in the rendered-config ConfigMap on the hub):

--- a/policies/stable/node-feature-discovery/manifests/node-feature-discovery-instance.yaml
+++ b/policies/stable/node-feature-discovery/manifests/node-feature-discovery-instance.yaml
@@ -7,7 +7,7 @@ spec:
   enableTaints: false
   instance: ''
   operand:
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.20
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.22
     imagePullPolicy: Always
     servicePort: 0
   prunerOnDelete: false

--- a/policies/stable/openshift-data-foundation/manifests/operator-install/kustomization.yaml
+++ b/policies/stable/openshift-data-foundation/manifests/operator-install/kustomization.yaml
@@ -14,7 +14,7 @@ helmCharts:
       remediation: ${REMEDIATION}
       subscription:
         name: '{{hub index .ManagedClusterLabels "autoshift.io/odf-subscription-name" | default "odf-operator" hub}}'
-        channel: '{{hub index .ManagedClusterLabels "autoshift.io/odf-channel" | default "stable-4.20" hub}}'
+        channel: '{{hub index .ManagedClusterLabels "autoshift.io/odf-channel" | default "stable-4.22" hub}}'
         source: '{{hub $base := (index .ManagedClusterLabels "autoshift.io/odf-source" | default "redhat-operators") hub}}{{hub ternary (printf "%s-%s" $base (index .ManagedClusterLabels "autoshift.io/mirror-catalog-suffix" | default "mirror")) $base (eq (index .ManagedClusterLabels "autoshift.io/disconnected-mirror" | default "false") "true") hub}}'
         sourceNamespace: '{{hub index .ManagedClusterLabels "autoshift.io/odf-source-namespace" | default "openshift-marketplace" hub}}'
         # Version resolution (config lives in the rendered-config ConfigMap on the hub):

--- a/policies/stable/openshift-data-foundation/manifests/storage-cluster-standalone.yaml
+++ b/policies/stable/openshift-data-foundation/manifests/storage-cluster-standalone.yaml
@@ -18,7 +18,6 @@ spec:
     cephRBDMirror: {}
     cephToolbox: {}
     cephDashboard: {}
-    cephConfig: {}
   mirroring: {}
   multiCloudGateway:
     reconcileStrategy: standalone

--- a/policies/stable/openshift-data-foundation/manifests/storage-cluster/storage-cluster.yaml
+++ b/policies/stable/openshift-data-foundation/manifests/storage-cluster/storage-cluster.yaml
@@ -70,7 +70,6 @@ object-templates-raw: |
             daemonCount: 1
           cephToolbox: {}
           cephDashboard: {}
-          cephConfig: {}
         arbiter: {}
         multiCloudGateway:
           reconcileStrategy: manage

--- a/policies/stable/openshift-upgrade/policy-generator-config.yaml
+++ b/policies/stable/openshift-upgrade/policy-generator-config.yaml
@@ -47,7 +47,7 @@ policies:
       noncompliant: >
         openshift-version '{{hub index .ManagedClusterLabels "autoshift.io/openshift-version" hub}}' is
         not a valid or available OpenShift update for this cluster on channel
-        '{{hub index .ManagedClusterLabels "autoshift.io/openshift-upgrade-channel" | default "stable-4.20" hub}}'
+        '{{hub index .ManagedClusterLabels "autoshift.io/openshift-upgrade-channel" | default "stable-4.22" hub}}'
         — check the version and channel against the cluster's available updates.
 
   # 3. The upgrade (enforce) — sets upstream + desiredUpdate (unless already Progressing). Blocked

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-shift/autoshiftv2/tools
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/stolostron/go-template-utils/v7 v7.3.0

--- a/tools/testdata/cluster-openshift-resources.yaml
+++ b/tools/testdata/cluster-openshift-resources.yaml
@@ -215,17 +215,17 @@ metadata:
   name: version
 spec:
   clusterID: fake-cluster-id-0001
-  channel: stable-4.20
+  channel: stable-4.22
 status:
   desired:
-    version: 4.20.11
+    version: 4.22.5
   history:
   - state: Completed
-    version: 4.20.11
-  # 4.20.29 (the _example openshift-version target) is offered as an available update, so the
+    version: 4.22.5
+  # 4.22.8 (the _example openshift-version target) is offered as an available update, so the
   # openshift-upgrade allowed-check resolves it as valid and the upgrade path is exercised.
   availableUpdates:
-  - version: 4.20.29
+  - version: 4.22.8
   conditions:
   - type: Available
     status: "True"


### PR DESCRIPTION
## Description

Updating to OCP 4.22

## Type of Change

- [ ] New policy (new operator or cluster configuration)
- [ ] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [ ] Other: <!-- describe -->

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
