### PR TITLE
Fixing sno cluster installs

### DIFF
--- a/docs/cluster-install.md
+++ b/docs/cluster-install.md
@@ -711,6 +711,35 @@ hub1:
 
 ## Single Node OpenShift (SNO)
 
+The setting differs by platform. Baremetal installs go through SiteConfig and use
+`controlPlaneAgents`. AWS and vSphere installs go through Hive and use replica counts.
+
+### AWS and vSphere (Hive)
+
+Set `controlPlane.replicas: 1` and `workers.replicas: 0` under the platform block:
+
+```yaml
+      aws:                       # or vmware:
+        controlPlane:
+          replicas: 1
+          instanceType: m5.2xlarge
+        workers:
+          replicas: 0
+```
+
+The single node runs the control plane and all workloads, so size the control plane
+accordingly — `m5.2xlarge` is the practical minimum on AWS.
+
+SNO also provisions into a single availability zone, so it needs one NAT gateway and
+one Elastic IP rather than one per zone. That matters on sandbox AWS accounts, where
+the Elastic IP quota is commonly 5 and a multi-zone install fails partway through
+network creation with `AddressLimitExceeded`.
+
+`workers.replicas: 0` produces a worker MachinePool with 0 replicas. That is expected
+and harmless: no MachineSets scale up.
+
+### Baremetal (SiteConfig)
+
 For single-node clusters, set `controlPlaneAgents: 1` and define one host:
 
 ```yaml

--- a/policies/stable/cluster-install/manifests/aws.yaml
+++ b/policies/stable/cluster-install/manifests/aws.yaml
@@ -46,7 +46,9 @@ object-templates-raw: |
   {{- $cpSize := (index $cpRootVolume "size" | default 100 | toInt) }}
   {{- $cpVolType := (index $cpRootVolume "type" | default "gp3") }}
   {{- $workers := (index $aws "workers" | default dict) }}
-  {{- $workerReplicas := (index $workers "replicas" | default 3 | toInt) }}
+  {{- /* `default` treats 0 as empty, so an explicit 0 would become 3 and SNO would be unreachable */ -}}
+  {{- $workerReplicas := 3 }}
+  {{- if hasKey $workers "replicas" }}{{- $workerReplicas = (index $workers "replicas" | toInt) }}{{- end }}
   {{- $wkInstanceType := (index $workers "instanceType" | default "m5.xlarge") }}
   {{- $wkRootVolume := (index $workers "rootVolume" | default dict) }}
   {{- $wkIops := (index $wkRootVolume "iops" | default 2000 | toInt) }}

--- a/policies/stable/cluster-install/manifests/vmware.yaml
+++ b/policies/stable/cluster-install/manifests/vmware.yaml
@@ -50,7 +50,9 @@ object-templates-raw: |
   {{- $cpMem := (index $controlPlane "memoryMB" | default 16384 | toInt) }}
   {{- $cpDisk := (index (index $controlPlane "osDisk" | default dict) "diskSizeGB" | default 120 | toInt) }}
   {{- $workers := (index $vsphere "workers" | default dict) }}
-  {{- $wkReplicas := (index $workers "replicas" | default 3 | toInt) }}
+  {{- /* `default` treats 0 as empty, so an explicit 0 would become 3 and SNO would be unreachable */ -}}
+  {{- $wkReplicas := 3 }}
+  {{- if hasKey $workers "replicas" }}{{- $wkReplicas = (index $workers "replicas" | toInt) }}{{- end }}
   {{- $wkCores := (index $workers "coresPerSocket" | default 2 | toInt) }}
   {{- $wkCpus := (index $workers "cpus" | default 8 | toInt) }}
   {{- $wkMem := (index $workers "memoryMB" | default 24576 | toInt) }}


### PR DESCRIPTION
Signed-off-by: Ben Carr <9310348+bcarr-rh@users.noreply.github.com>

## Description

Fixing SNO clusters from creating workers when default is triggered in aws and vmware

## Type of Change

- [ ] Bug fix (incorrect template, label logic, chart rendering)

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
