### PR TITLE
Fixing stale references and outdated test logic

### DIFF
--- a/policies/certified/cloudnative-pg/README.md
+++ b/policies/certified/cloudnative-pg/README.md
@@ -11,8 +11,10 @@ This policy installs the cloudnative-pg operator using AutoShift patterns.
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/cloudnative-pg/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -253,9 +255,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/cloudnative-pg/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/cloudnative-pg/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/cloudnative-pg) - Find your operator details

--- a/policies/certified/gitlab-runner/README.md
+++ b/policies/certified/gitlab-runner/README.md
@@ -11,8 +11,10 @@ This policy installs the gitlab-runner-operator operator using AutoShift pattern
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/gitlab-runner/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -253,9 +255,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/gitlab-runner/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/gitlab-runner/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/gitlab-runner-operator) - Find your operator details

--- a/policies/stable/cert-manager/README.md
+++ b/policies/stable/cert-manager/README.md
@@ -74,8 +74,10 @@ settles (PROGRESSING True→False), then `cert-manager-ingress-cert`.
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/cert-manager/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -316,9 +318,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/cert-manager/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/cert-manager/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/openshift-cert-manager-operator) - Find your operator details

--- a/policies/stable/external-secrets-operator/README.md
+++ b/policies/stable/external-secrets-operator/README.md
@@ -11,8 +11,10 @@ This policy installs the external-secrets-operator operator using AutoShift patt
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/external-secrets-operator/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -253,9 +255,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/external-secrets-operator/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/external-secrets-operator/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/external-secrets-operator) - Find your operator details

--- a/policies/stable/kiali/README.md
+++ b/policies/stable/kiali/README.md
@@ -11,8 +11,10 @@ This policy installs the kiali-ossm operator using AutoShift patterns.
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/kiali/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -247,9 +249,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/kiali/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/kiali/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/kiali-ossm) - Find your operator details

--- a/policies/stable/nmstate/README.md
+++ b/policies/stable/nmstate/README.md
@@ -445,13 +445,15 @@ The `_validate-cluster-install.tpl` validates at Helm render time:
 
 ## Testing
 
-```bash
-# Render nmstate chart
-helm template test policies/stable/nmstate/ -f policies/nmstate/values.yaml
+This is a PolicyGenerator directory, not a Helm chart — there is no `values.yaml` to pass. Config
+reaches the policy at enforcement time through the cluster's `rendered-config` ConfigMap, built from
+`autoshift/values/`, so the suite seeds that from the `_example*.yaml` files rather than taking a
+values file on the command line.
 
-# Render with cluster values
-helm template test policies/stable/nmstate/ -f policies/nmstate/values.yaml \
-  -f autoshift/values/global.yaml \
-  -f autoshift/values/clustersets/hub.yaml \
-  -f autoshift/values/clusters/test-cluster.yaml
+```bash
+# Render every policy, resolve hub and spoke templates, check the label contract. What CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
+
+Per-cluster nmstate config is exercised through `autoshift/values/clusters/_example-cluster-install-*.yaml`
+— one managed-cluster profile is generated per file, so adding one adds a profile automatically.

--- a/policies/stable/node-feature-discovery/README.md
+++ b/policies/stable/node-feature-discovery/README.md
@@ -11,8 +11,10 @@ This policy installs the nfd operator using AutoShift patterns.
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/node-feature-discovery/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -247,9 +249,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/node-feature-discovery/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/node-feature-discovery/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/nfd) - Find your operator details

--- a/policies/stable/node-maintenance/README.md
+++ b/policies/stable/node-maintenance/README.md
@@ -11,8 +11,10 @@ This policy installs the node-maintenance-operator operator using AutoShift patt
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/node-maintenance/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -253,9 +255,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/node-maintenance/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/node-maintenance/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/node-maintenance-operator) - Find your operator details

--- a/policies/stable/servicemesh3-ambient/README.md
+++ b/policies/stable/servicemesh3-ambient/README.md
@@ -107,25 +107,21 @@ servicemesh3-ambient: 'true'
 - **ServiceMonitor**: Prometheus scraping for istiod metrics
 - **PodMonitor**: Prometheus scraping for ZTunnel metrics
 
-## Values Configuration
+## Configuration
 
-Key values in `policies/servicemesh3-ambient/values.yaml`:
+This is a PolicyGenerator directory — there is no `values.yaml`. Configuration comes from
+`autoshift.io/*` labels, read at enforcement time by hub templates in `manifests/`:
 
-```yaml
-servicemesh3operator:
-  namespace: openshift-operators
-  istioNamespace: istio-system
-  istioCNINamespace: istio-cni
-  ztunnelNamespace: ztunnel
-  istioVersion: v1.28-latest
-  updateStrategy: InPlace
-  tempoNamespace: tracing-system
-  pilot:
-    cpuRequest: "100m"
-    memoryRequest: "256Mi"
-  tempo:
-    storageSize: 10Gi
-```
+| Label | Default | Effect |
+|---|---|---|
+| `servicemesh3-ambient` | `false` | Gates the Placement — nothing deploys unless `true` |
+| `servicemesh3operator-istio-version` | `v1.28-latest` | `version` on the Istio and IstioCNI CRs |
+| `servicemesh3operator-tempo` | `false` | Wires Kiali to Tempo for distributed tracing |
+
+Set them in a clusterset or per-cluster values file; see `autoshift/values/clustersets/_example.yaml`.
+
+The mesh namespaces (`istio-system`, `istio-cni`, `ztunnel`) are fixed in `manifests/` and are not
+configurable — the manifests reference them directly, and the operator expects `ztunnel` by name.
 
 ## Using the Mesh
 

--- a/policies/stable/servicemesh3operator/README.md
+++ b/policies/stable/servicemesh3operator/README.md
@@ -13,8 +13,10 @@ This policy installs the **Sail Operator** (servicemeshoperator3) for OpenShift 
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/servicemesh3operator/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -123,9 +125,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/servicemesh3operator/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/servicemesh3operator/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/servicemeshoperator3) - Find your operator details

--- a/policies/stable/tempo/README.md
+++ b/policies/stable/tempo/README.md
@@ -11,8 +11,10 @@ This policy installs the tempo-product operator using AutoShift patterns.
 
 ### Test Locally
 ```bash
-# Validate policy renders correctly
-helm template policies/tempo/
+# A PolicyGenerator directory, not a Helm chart: rendering it needs the ${...}
+# placeholders substituted first. The validation suite does that, resolves hub and
+# spoke templates, and is what CI runs.
+cd tools && go test -tags integration ./internal/resolver/...
 ```
 
 ### Enable on Clusters
@@ -247,9 +249,9 @@ For operators that need installation verification:
 3. Verify operator source exists: `oc get catalogsource -n openshift-marketplace`
 
 ### Template Rendering Issues
-1. Test locally: `helm template policies/tempo/`
+1. Validate rendering: `cd tools && go test -tags integration ./internal/resolver/...`
 2. Check hub escaping: Look for `{{ "{{hub" }} ... {{ "hub}}" }}` patterns
-3. Validate YAML: `helm lint policies/tempo/`
+3. Read the failure: the suite names the chart and the stage that failed (render, hub resolution, spoke resolution, YAML validation, label contract)
 
 ## Resources
 - [Operator Documentation](https://operatorhub.io/operator/tempo-product) - Find your operator details


### PR DESCRIPTION
Signed-off-by: Ben Carr <9310348+bcarr-rh@users.noreply.github.com>

## Description

Fixing broken links in policy level readme files

## Type of Change

- [ ] Documentation update

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
