### PR TITLE
Fixing Argo Size for policy generator

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -113,9 +113,14 @@ hubClusterSets:
       # =======================================================================
       disconnected:
         mirrorRegistry:
-          host: 'registry.example.com'
-          port: '5000'
+          host: 'registry.example.com:5000'    # host:port — there is no separate port key
           path: 'openshift'
+          # ca (inline bundle) or caRef (hub ConfigMap) is required once mirrors/tagMirrors or
+          # catalogs are defined; the mirrored registry is not in the cluster's default trust.
+          caRef:
+            name: 'cluster-ca-bundle'
+            key: 'ca-bundle.crt'
+            namespace: 'cluster-install-secrets'
           mirrors:
             - source: 'registry.redhat.io'
               mirror: 'registry.example.com:5000/rhel'
@@ -127,11 +132,16 @@ hubClusterSets:
           tagMirrors:
             - source: 'docker.io/hashicorp'
               mirror: 'registry.example.com:5000/hashicorp'
+        # imagePath and tag, not a single image string — the host comes from mirrorRegistry above.
         catalogs:
           - source: redhat-operators
-            image: 'registry.example.com:5000/redhat/redhat-operator-index:v4.22'
+            imagePath: redhat/redhat-operator-index
+            tag: v4.22
+            publisher: Red Hat
           - source: certified-operators
-            image: 'registry.example.com:5000/redhat/certified-operator-index:v4.22'
+            imagePath: redhat/certified-operator-index
+            tag: v4.22
+            publisher: Red Hat
         useIDMS: true
         disableDefaultCatalogs: true
       # =======================================================================
@@ -300,7 +310,7 @@ hubClusterSets:
           node-role.kubernetes.io/worker: ''
         numaTopology: 'restricted'
         hugepages:
-          defaultHugepagesSize: '1G'
+          defaultSize: '1G'
           pages:
             - size: '1G'
               count: 4
@@ -496,6 +506,23 @@ hubClusterSets:
           provider: openshift               # '' disables the declarative auth config
           minimumRole: None                 # minimum role for authenticated users
           adminGroup: cluster-admins        # group mapped to the Admin role
+      # =======================================================================
+      # AutoShift Console Plugin (hub only; ENABLE flag is the autoshift-console label).
+      # Read-only OpenShift console plugin that surfaces AutoShift clustersets, the resolution
+      # chain behind each setting, and policy compliance. Both keys are optional.
+      # =======================================================================
+      autoshiftConsole:
+        # Built per OpenShift minor — the console supplies react and react-router as shared
+        # singletons, so one bundle cannot span releases. The tag names the minor it targets and
+        # there is no bare :latest. Pin a digest in production.
+        image: 'quay.io/autoshift/autoshift-console-plugin:ocp4.22'
+        replicas: 2
+        # Minimum OpenShift version the plugin can run on. The policy reads the cluster's ACTUAL
+        # running version and deploys nothing below this, because an incompatible console skips
+        # the plugin silently — the pod runs and serves assets but nothing appears in the UI.
+        # Must match @console/pluginAPI in the plugin's package.json; ACM templates cannot read
+        # that file, so the two are kept in step by CI rather than derived.
+        minOpenShiftVersion: '4.22.0-0'
     labels:
       # =======================================================================
       # Core Configuration
@@ -530,6 +557,12 @@ hubClusterSets:
       gitops-source-namespace: openshift-marketplace
       gitops-namespace: 'openshift-gitops'          # Override ArgoCD namespace per-cluster
       gitops-cluster-ca-bundle: 'true'              # Inject cluster trusted CA bundle into ArgoCD repo server
+
+      # =======================================================================
+      # AutoShift Console Plugin (hub only — reads hub-side AutoShift ConfigMaps)
+      # Image and replicas are set under config.autoshiftConsole above.
+      # =======================================================================
+      autoshift-console: 'true'                     # add the AutoShift section to the console sidebar
 
       # =======================================================================
       # Advanced Cluster Management (hub only — not installed on managed clusters)

--- a/openshift-gitops/templates/argo-cd.yaml
+++ b/openshift-gitops/templates/argo-cd.yaml
@@ -200,7 +200,8 @@ spec:
     resources:
       limits:
         cpu: {{ ((.Values.gitops.controller).limits).cpu | default "2000m" }}
-        memory: {{ ((.Values.gitops.controller).limits).memory | default "2048Mi" }}
+        # 4Gi: the controller OOMKills at 2Gi once the ApplicationSet has fanned out to all policies/*.
+        memory: {{ ((.Values.gitops.controller).limits).memory | default "4096Mi" }}
       requests:
         cpu: {{ ((.Values.gitops.controller).requests).cpu | default "250m" }}
         memory: {{ ((.Values.gitops.controller).requests).memory | default "1024Mi" }}

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -2,10 +2,6 @@
 # the GitOps Operator.
 #
 {{- if .Values.hubClusterSets }}
-{{- /* The CMP init/sidecar images are resolved at policy-enforcement time via hub-template lookups in
-       object-templates-raw below — a helm lookup here would not work, because ArgoCD's repo-server does
-       not execute helm lookups during rendering. The PolicyGenerator CMP is unconditional: the repo-server
-       cannot render any of the kustomize/PolicyGenerator policies without it. */}}
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -181,11 +177,11 @@ spec:
                   repo:
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $repoLimits "cpu" | default "1000m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $repoLimits "memory" | default "1024Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $repoLimits "cpu" | default "2000m" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $repoLimits "memory" | default "2048Mi" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $repoRequests "cpu" | default "250m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $repoRequests "memory" | default "256Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $repoRequests "cpu" | default "500m" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $repoRequests "memory" | default "512Mi" {{ "hub}}" }}
                     {{ "{{hub-" }} if $pgEnabled {{ "hub}}" }}
                     env:
                       - name: POLICY_GEN_ENABLE_HELM
@@ -287,7 +283,7 @@ spec:
                     resources:
                       limits:
                         cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default "2000m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default "2048Mi" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default "4096Mi" {{ "hub}}" }}
                       requests:
                         cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default "250m" {{ "hub}}" }}
                         memory: {{ "{{hub" }} index $controllerRequests "memory" | default "1024Mi" {{ "hub}}" }}

--- a/policies/stable/openshift-gitops/values.yaml
+++ b/policies/stable/openshift-gitops/values.yaml
@@ -68,10 +68,11 @@ gitops:
   # policies in the hub repo-server. Required for GIT/source deployments. Adds an init
   # container (stages the PG binary from the ACM subscription image) and a CMP sidecar that
   # runs `kustomize build --enable-alpha-plugins` after substituting the per-deployment
-  # ${...} placeholders. See openshift-gitops/templates/argo-cd.yaml.
+  # ${...} placeholders. Defined in templates/policy-gitops-systems-argocd.yaml.
   # Gated by gitops.policyGenerator.enabled (above): OCI-only deployments consume prerendered Helm
   # charts and set it false to omit the sidecar. Its init/sidecar images are resolved at enforcement
-  # time via hub-template lookups in templates/policy-gitops-systems-argocd.yaml.
+  # time by spoke-side lookups of the running repo-server and ACM subscription deployments, so they
+  # always match the versions on the cluster.
   server:
     autoscale:
       enabled: true

--- a/tools/internal/resolver/autoshift_chart_test.go
+++ b/tools/internal/resolver/autoshift_chart_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAutoShiftChart_ValuesProfiles renders the top-level autoshift/ chart against every values
+// profile in the repo.
+//
+// This is the only thing that executes autoshift/templates/_validate-*.tpl. TestPipeline_EndToEnd
+// renders policies/ charts and consumes autoshift/values/ as data — it reads the label declarations
+// and builds ConfigMaps from hubClusterSets.*.config — but it never renders the chart those values
+// are actually written for. So a values file could name a key no schema recognises, or omit a
+// required one, and every policy would still resolve cleanly against it: the policies read the keys
+// they know about and are indifferent to the rest.
+//
+// That gap was real. _example.yaml carried disconnected.mirrorRegistry.port (no such field),
+// catalogs[].image instead of imagePath + tag, hugepages.defaultHugepagesSize instead of
+// defaultSize, and no CA — four violations the validator catches instantly and nothing ever ran it.
+//
+// The release name is the chart directory's base name, "autoshift" at 9 characters, which keeps the
+// derived policy namespace inside the 20-character limit _validate-naming.tpl enforces.
+func TestAutoShiftChart_ValuesProfiles(t *testing.T) {
+	root := repoRoot(t)
+
+	chartDir := filepath.Join(root, "autoshift")
+	globalValues := filepath.Join(root, "autoshift", "values", "global.yaml")
+	for _, p := range []string{chartDir, globalValues} {
+		if _, err := os.Stat(p); err != nil {
+			t.Skipf("required path missing, skipping: %s", p)
+		}
+	}
+
+	clusterSets := globValues(t, filepath.Join(root, "autoshift", "values", "clustersets"))
+	if len(clusterSets) == 0 {
+		t.Fatal("no clusterset values files found — the chart would go unvalidated")
+	}
+
+	// A clusterset profile stands alone: global.yaml plus the profile is what an Application
+	// actually renders in the simplest deployment.
+	for _, vf := range clusterSets {
+		t.Run("clusterset/"+filepath.Base(vf), func(t *testing.T) {
+			renderChart(t, chartDir, globalValues, vf)
+		})
+	}
+
+	// A per-cluster override is a delta layered on a clusterset, never a whole configuration, so it
+	// is rendered on top of the reference profile. _example.yaml declares every option, which makes
+	// it the strictest base to layer onto.
+	base := filepath.Join(root, "autoshift", "values", "clustersets", "_example.yaml")
+	if _, err := os.Stat(base); err != nil {
+		t.Logf("no _example.yaml clusterset; skipping per-cluster overrides")
+		return
+	}
+	for _, vf := range globValues(t, filepath.Join(root, "autoshift", "values", "clusters")) {
+		t.Run("cluster/"+filepath.Base(vf), func(t *testing.T) {
+			renderChart(t, chartDir, globalValues, base, vf)
+		})
+	}
+}
+
+// globValues returns the .yaml files in dir, sorted, or nothing if dir is absent.
+func globValues(t *testing.T, dir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", dir, err)
+	}
+	return matches
+}
+
+// renderChart fails the test if helm template errors or produces nothing.
+//
+// The empty-output check is not redundant: the chart's guards use `fail`, but a values file that
+// disabled every generator would exit zero having emitted nothing, and an ApplicationSet that
+// deploys no policies is a silent failure rather than a working minimal install.
+func renderChart(t *testing.T, chartDir string, valuesFiles ...string) {
+	t.Helper()
+
+	out, err := HelmTemplate(chartDir, valuesFiles...)
+	if err != nil {
+		// The validator reports every violation at once, so print the lot rather than making the
+		// author rerun for each in turn.
+		t.Fatalf("helm template failed:\n%v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("rendered zero documents")
+	}
+}


### PR DESCRIPTION
Adding test for _example.yamls rendering with helm

## Description

Fixing argo size for policy generator with all policies.

Added check to catch drift in _example.yaml

## Type of Change

- [x] Bug fix (incorrect template, label logic, chart rendering)
- [x] CI/tooling change

## Checklist

- [x] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [x] `helm template policies/stable/<name>/` renders without errors
- [x] `cd tools && go test -tags integration ./...` passes
- [x] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [x] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [x] Policy README.md included or updated
- [x] No hardcoded values — hub templates used where cluster-specific values are needed
- [x] Tested in a dev/sandbox environment
- [x] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
