### PR TITLE
Substitute CLUSTER_SET_SUFFIX in the policy-generator CMP

### DIFF
--- a/openshift-gitops/templates/policy-generator-cmp.yaml
+++ b/openshift-gitops/templates/policy-generator-cmp.yaml
@@ -34,6 +34,8 @@ data:
             REM="${ARGOCD_ENV_REMEDIATION:-${REMEDIATION:-enforce}}"
             EC="${ARGOCD_ENV_EVAL_COMPLIANT:-${EVAL_COMPLIANT:-10m}}"
             EN="${ARGOCD_ENV_EVAL_NONCOMPLIANT:-${EVAL_NONCOMPLIANT:-30s}}"
+            # Empty unless versionedClusterSets; cluster-install appends it to clusterset names.
+            CSS="${ARGOCD_ENV_CLUSTER_SET_SUFFIX:-${CLUSTER_SET_SUFFIX:-}}"
             # sed (envsubst is not in the argocd image), restricted to these exact tokens so
             # hub-template $vars ($base, $cm, ...) inside manifests/ are never touched.
             find . -type f -name '*.yaml' -exec sed -i \
@@ -41,6 +43,7 @@ data:
               -e "s|\${REMEDIATION}|${REM}|g" \
               -e "s|\${EVAL_COMPLIANT}|${EC}|g" \
               -e "s|\${EVAL_NONCOMPLIANT}|${EN}|g" \
+              -e "s|\${CLUSTER_SET_SUFFIX}|${CSS}|g" \
               {} +
             # A policy manifest path may be a nested kustomization that renders a shared chart from
             # components/. PolicyGenerator spawns a nested `kustomize build` for it, configured by


### PR DESCRIPTION


## Description

  The ApplicationSet already passed CLUSTER_SET_SUFFIX as a plugin env var and
  both render scripts and the resolver harness already replaced the token, but
  the repo-server CMP did not. Policies reaching the cluster through a git-mode
  sync kept the literal ${CLUSTER_SET_SUFFIX}, so cluster-install and
  cluster-set-assignment built clusterset names containing the raw token
  whenever versionedClusterSets was on.

## Type of Change

- [ ] Bug fix (incorrect template, label logic, chart rendering)

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
