### PR TITLE
feat: config-driven ODF StorageCluster and local-storage

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -429,6 +429,27 @@ hubClusterSets:
       #   versions:
       #     - 'odf-operator.vX.Y.Z'
       #   startingCSV: 'odf-operator.vX.Y.Z'
+      #   # Config-driven StorageCluster — when set, replaces the entire label-driven
+      #   # StorageCluster spec. When absent, the existing label-driven default applies.
+      #   storageCluster:
+      #     enableCephTools: true
+      #     resourceProfile: Lean
+      #     monDataDirHostPath: /var/lib/rook
+      #     multiCloudGateway:
+      #       reconcileStrategy: ignore
+      #     storageDeviceSets:
+      #       - name: nvme-set
+      #         deviceClass: nvme
+      #         count: 1
+      #         replica: 3
+      #         dataPVCTemplate:
+      #           spec:
+      #             storageClassName: local-nvme
+      #             accessModes: [ReadWriteOnce]
+      #             volumeMode: Block
+      #             resources:
+      #               requests:
+      #                 storage: 1
       # opentelemetry:
       #   versions:
       #     - 'opentelemetry-product.vX.Y.Z'
@@ -453,31 +474,6 @@ hubClusterSets:
       #   versions:
       #     - 'kubevirt-hyperconverged.vX.Y.Z'
       #   startingCSV: 'kubevirt-hyperconverged.vX.Y.Z'
-      # =======================================================================
-      # ODF StorageCluster (config-driven)
-      # When set, replaces the entire label-driven StorageCluster spec.
-      # When absent, the existing label-driven default applies unchanged.
-      # =======================================================================
-      # odf:
-      #   storageCluster:
-      #     enableCephTools: true
-      #     resourceProfile: Lean
-      #     monDataDirHostPath: /var/lib/rook
-      #     multiCloudGateway:
-      #       reconcileStrategy: ignore
-      #     storageDeviceSets:
-      #       - name: nvme-set
-      #         deviceClass: nvme
-      #         count: 1
-      #         replica: 3
-      #         dataPVCTemplate:
-      #           spec:
-      #             storageClassName: local-nvme
-      #             accessModes: [ReadWriteOnce]
-      #             volumeMode: Block
-      #             resources:
-      #               requests:
-      #                 storage: 1
       # =======================================================================
       # Local Storage (config-driven)
       # Named volume sets under localVolumeSets.<id>; each field has a sensible

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -423,6 +423,56 @@ hubClusterSets:
       #     - 'kubevirt-hyperconverged.vX.Y.Z'
       #   startingCSV: 'kubevirt-hyperconverged.vX.Y.Z'
       # =======================================================================
+      # ODF StorageCluster (config-driven)
+      # When set, replaces the entire label-driven StorageCluster spec.
+      # When absent, the existing label-driven default applies unchanged.
+      # =======================================================================
+      # odf:
+      #   storageCluster:
+      #     enableCephTools: true
+      #     resourceProfile: Lean
+      #     monDataDirHostPath: /var/lib/rook
+      #     multiCloudGateway:
+      #       reconcileStrategy: ignore
+      #     storageDeviceSets:
+      #       - name: nvme-set
+      #         deviceClass: nvme
+      #         count: 1
+      #         replica: 3
+      #         dataPVCTemplate:
+      #           spec:
+      #             storageClassName: local-nvme
+      #             accessModes: [ReadWriteOnce]
+      #             volumeMode: Block
+      #             resources:
+      #               requests:
+      #                 storage: 1
+      # =======================================================================
+      # Local Storage (config-driven)
+      # Named volume sets under localVolumeSets.<id>; each field has a sensible
+      # default so you only need to set what you want to override:
+      #   storageClassName  → nvme-storageclass
+      #   volumeMode        → Block
+      #   deviceInclusionSpec → {deviceTypes: [disk], minSize: 200G}
+      #   nodeSelector      → cluster.ocs.openshift.io/openshift-storage: Exists
+      #   tolerations       → node.ocs.openshift.io/storage: NoSchedule
+      # When absent, a single default nvme-localvolumeset is created.
+      # =======================================================================
+      # localStorage:
+      #   localVolumeDiscovery:
+      #     nodeSelector:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #             - key: cluster.ocs.openshift.io/openshift-storage
+      #               operator: Exists
+      #   localVolumeSets:
+      #     nvme:
+      #       storageClassName: local-nvme
+      #       volumeMode: Block
+      #       deviceInclusionSpec:
+      #         deviceTypes: [disk]
+      #         deviceMechanicalProperties: [NonRotational]
+      # =======================================================================
       # Workload Partitioning (CPU isolation via PerformanceProfile)
       # =======================================================================
       workloadPartitioning:

--- a/autoshift/values/clustersets/non-ha-acps-odf-custom-example.yaml
+++ b/autoshift/values/clustersets/non-ha-acps-odf-custom-example.yaml
@@ -1,0 +1,149 @@
+# Non-HA ACP Spoke Cluster Sets — ODF & local-storage custom config example.
+#
+# Demonstrates config-driven overrides for the ODF StorageCluster and
+# local-storage LocalVolumeSet / LocalVolumeDiscovery CRs.  The config
+# section is merged into the per-cluster rendered-config ConfigMap on the
+# hub; policy templates consume it via hub template lookups.
+#
+# Operators whose templates read from rendered-config:
+#   - ODF StorageCluster  (config.odf.storageCluster)
+#   - Local Storage        (config.localStorage.{localVolumeDiscovery,localVolumeSets})
+#   - cert-manager        (config.certManager.{ca,apiCert,ingressCert})
+#   - NMState             (config.networking)
+#   - UWM                 (config.uwm)
+managedClusterSets:
+  non-ha-acps:
+    config:
+      # ── ODF StorageCluster overrides ──────────────────────────────────
+      # Everything under config.odf.storageCluster maps 1-to-1 with the
+      # StorageCluster CR spec.  When present, it replaces the default
+      # label-driven spec entirely.
+      odf:
+        storageCluster:
+          enableCephTools: true
+          manageNodes: false
+          failureDomain: host
+          failureDomainKey: kubernetes.io/hostname
+          performanceProfile: Lean
+          managedResources:
+            cephBlockPools:
+              reconcileStrategy: ignore
+          storageDeviceSets:
+            - name: nvme-set
+              deviceClass: nvme
+              count: 1
+              replica: 3
+              placement: {}
+              dataPVCTemplate:
+                spec:
+                  storageClassName: local-nvme
+                  accessModes:
+                    - ReadWriteOnce
+                  volumeMode: Block
+                  resources:
+                    requests:
+                      storage: 1
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+                requests:
+                  cpu: "1"
+                  memory: 2Gi
+            - name: ssd-set
+              deviceClass: ssd
+              count: 1
+              replica: 3
+              placement: {}
+              dataPVCTemplate:
+                spec:
+                  storageClassName: local-ssd
+                  accessModes:
+                    - ReadWriteOnce
+                  volumeMode: Block
+                  resources:
+                    requests:
+                      storage: 1
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+                requests:
+                  cpu: "1"
+                  memory: 2Gi
+      # ── Local Storage overrides ─────────────────────────────────────
+      # localVolumeDiscovery: creates a LocalVolumeDiscovery CR (optional).
+      # localVolumeSets: dict keyed by name; each entry becomes a
+      #   LocalVolumeSet CR named "<key>-localvolumeset".
+      # When localVolumeSets is absent, the default hardcoded
+      # nvme-localvolumeset (disks >= 200G on OCS nodes) is created.
+      localStorage:
+        localVolumeDiscovery:
+          nodeSelector:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: cluster.ocs.openshift.io/openshift-storage
+                    operator: Exists
+          tolerations:
+            - effect: NoSchedule
+              key: node.ocs.openshift.io/storage
+              operator: Exists
+        localVolumeSets:
+          nvme:
+            storageClassName: local-nvme
+            volumeMode: Block
+            deviceInclusionSpec:
+              deviceTypes:
+                - disk
+              deviceMechanicalProperties:
+                - NonRotational
+              minSize: 200G
+            nodeSelector:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cluster.ocs.openshift.io/openshift-storage
+                      operator: Exists
+            tolerations:
+              - effect: NoSchedule
+                key: node.ocs.openshift.io/storage
+                operator: Exists
+          ssd:
+            storageClassName: local-ssd
+            volumeMode: Block
+            deviceInclusionSpec:
+              deviceTypes:
+                - disk
+              deviceMechanicalProperties:
+                - Rotational
+              minSize: 100G
+            nodeSelector:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cluster.ocs.openshift.io/openshift-storage
+                      operator: Exists
+            tolerations:
+              - effect: NoSchedule
+                key: node.ocs.openshift.io/storage
+                operator: Exists
+    labels:
+      ### Local Storage Operator
+      local-storage: 'true'
+      local-storage-subscription-name: local-storage-operator
+      local-storage-channel: stable
+      local-storage-source: redhat-operators
+      local-storage-source-namespace: openshift-marketplace
+      ### OpenShift Data Foundation
+      odf: 'true'
+      odf-subscription-name: odf-operator
+      odf-multi-cloud-gateway: standard
+      # Label-driven ODF knobs still apply as fallback defaults when the
+      # config block doesn't specify a value.  With a full
+      # config.odf.storageCluster block (above), these are secondary:
+      odf-ocs-storage-class-name: gp3-csi
+      odf-ocs-storage-size: ''
+      odf-ocs-storage-count: ''
+      odf-ocs-storage-replicas: ''
+      odf-resource-profile: lean
+      odf-channel: stable-4.20
+      odf-source: redhat-operators
+      odf-source-namespace: openshift-marketplace

--- a/policies/stable/local-storage/manifests/local-volume-set.yaml
+++ b/policies/stable/local-storage/manifests/local-volume-set.yaml
@@ -1,21 +1,54 @@
-apiVersion: local.storage.openshift.io/v1alpha1
-kind: LocalVolumeSet
-metadata:
-  name: nvme-localvolumeset
-  namespace: openshift-local-storage
-spec:
-  deviceInclusionSpec:
-    deviceTypes:
-    - disk
-    minSize: 200G
-  nodeSelector:
-    nodeSelectorTerms:
-    - matchExpressions:
-      - key: cluster.ocs.openshift.io/openshift-storage
-        operator: Exists
-  storageClassName: nvme-storageclass
-  tolerations:
-  - effect: NoSchedule
-    key: node.ocs.openshift.io/storage
-    operator: Exists
-  volumeMode: Block
+object-templates-raw: |
+  {{hub $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml) hub}}
+  {{hub- $ls := (index $config "localStorage" | default dict) hub}}
+  {{hub- $discovery := (index $ls "localVolumeDiscovery" | default dict) hub}}
+  {{hub- $volumeSets := (index $ls "localVolumeSets" | default dict) hub}}
+  {{hub- if (gt (len (keys $discovery)) 0) hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: local.storage.openshift.io/v1alpha1
+      kind: LocalVolumeDiscovery
+      metadata:
+        name: auto-discover-devices
+        namespace: openshift-local-storage
+      spec:
+        {{hub $discovery | toYaml | autoindent hub}}
+  {{hub- end hub}}
+  {{hub- if (gt (len (keys $volumeSets)) 0) hub}}
+  {{hub- range $id, $vs := $volumeSets hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: local.storage.openshift.io/v1alpha1
+      kind: LocalVolumeSet
+      metadata:
+        name: {{hub $id hub}}-localvolumeset
+        namespace: openshift-local-storage
+      spec:
+        {{hub $vs | toYaml | autoindent hub}}
+  {{hub- end hub}}
+  {{hub- else hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: local.storage.openshift.io/v1alpha1
+      kind: LocalVolumeSet
+      metadata:
+        name: nvme-localvolumeset
+        namespace: openshift-local-storage
+      spec:
+        deviceInclusionSpec:
+          deviceTypes:
+          - disk
+          minSize: 200G
+        nodeSelector:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: cluster.ocs.openshift.io/openshift-storage
+              operator: Exists
+        storageClassName: nvme-storageclass
+        tolerations:
+        - effect: NoSchedule
+          key: node.ocs.openshift.io/storage
+          operator: Exists
+        volumeMode: Block
+  {{hub- end hub}}

--- a/policies/stable/local-storage/manifests/local-volume-set.yaml
+++ b/policies/stable/local-storage/manifests/local-volume-set.yaml
@@ -1,6 +1,6 @@
 object-templates-raw: |
-  {{hub $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) hub}}
-  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml) hub}}
+  {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml | default dict) hub}}
   {{hub- $ls := (index $config "localStorage" | default dict) hub}}
   {{hub- $discovery := (index $ls "localVolumeDiscovery" | default dict) hub}}
   {{hub- $volumeSets := (index $ls "localVolumeSets" | default dict) hub}}
@@ -17,7 +17,12 @@ object-templates-raw: |
   {{hub- end hub}}
   {{hub- if (gt (len (keys $volumeSets)) 0) hub}}
   {{hub- range $id, $vs := $volumeSets hub}}
-  - complianceType: musthave
+  {{hub- $storageClassName := (index $vs "storageClassName" | default "nvme-storageclass") hub}}
+  {{hub- $volumeMode := (index $vs "volumeMode" | default "Block") hub}}
+  {{hub- $deviceInclusionSpec := (index $vs "deviceInclusionSpec" | default dict) hub}}
+  {{hub- $nodeSelector := (index $vs "nodeSelector" | default dict) hub}}
+  {{hub- $tolerations := (index $vs "tolerations" | default list) hub}}
+  - complianceType: mustonlyhave
     objectDefinition:
       apiVersion: local.storage.openshift.io/v1alpha1
       kind: LocalVolumeSet
@@ -25,10 +30,39 @@ object-templates-raw: |
         name: {{hub $id hub}}-localvolumeset
         namespace: openshift-local-storage
       spec:
-        {{hub $vs | toYaml | autoindent hub}}
+        storageClassName: {{hub $storageClassName hub}}
+        volumeMode: {{hub $volumeMode hub}}
+  {{hub- if (gt (len (keys $deviceInclusionSpec)) 0) hub}}
+        deviceInclusionSpec:
+          {{hub $deviceInclusionSpec | toYaml | autoindent hub}}
+  {{hub- else hub}}
+        deviceInclusionSpec:
+          deviceTypes:
+          - disk
+          minSize: 200G
+  {{hub- end hub}}
+  {{hub- if (gt (len (keys $nodeSelector)) 0) hub}}
+        nodeSelector:
+          {{hub $nodeSelector | toYaml | autoindent hub}}
+  {{hub- else hub}}
+        nodeSelector:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: cluster.ocs.openshift.io/openshift-storage
+              operator: Exists
+  {{hub- end hub}}
+  {{hub- if (gt (len $tolerations) 0) hub}}
+        tolerations:
+          {{hub $tolerations | toYaml | autoindent hub}}
+  {{hub- else hub}}
+        tolerations:
+        - effect: NoSchedule
+          key: node.ocs.openshift.io/storage
+          operator: Exists
+  {{hub- end hub}}
   {{hub- end hub}}
   {{hub- else hub}}
-  - complianceType: musthave
+  - complianceType: mustonlyhave
     objectDefinition:
       apiVersion: local.storage.openshift.io/v1alpha1
       kind: LocalVolumeSet
@@ -36,6 +70,8 @@ object-templates-raw: |
         name: nvme-localvolumeset
         namespace: openshift-local-storage
       spec:
+        storageClassName: nvme-storageclass
+        volumeMode: Block
         deviceInclusionSpec:
           deviceTypes:
           - disk
@@ -45,10 +81,8 @@ object-templates-raw: |
           - matchExpressions:
             - key: cluster.ocs.openshift.io/openshift-storage
               operator: Exists
-        storageClassName: nvme-storageclass
         tolerations:
         - effect: NoSchedule
           key: node.ocs.openshift.io/storage
           operator: Exists
-        volumeMode: Block
   {{hub- end hub}}

--- a/policies/stable/openshift-data-foundation/manifests/storage-cluster/storage-cluster.yaml
+++ b/policies/stable/openshift-data-foundation/manifests/storage-cluster/storage-cluster.yaml
@@ -1,4 +1,8 @@
 object-templates-raw: |
+  {{hub $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml) hub}}
+  {{hub- $odf := (index $config "odf" | default dict) hub}}
+  {{hub- $storageCluster := (index $odf "storageCluster" | default dict) hub}}
   - complianceType: musthave
     objectDefinition:
       apiVersion: ocs.openshift.io/v1
@@ -6,6 +10,10 @@ object-templates-raw: |
       metadata:
         name: ocs-storagecluster
         namespace: openshift-storage
+  {{hub- if (gt (len (keys $storageCluster)) 0) hub}}
+      spec:
+        {{hub $storageCluster | toYaml | autoindent hub}}
+  {{hub- else hub}}
       spec:
         storageDeviceSets:
           - config: {}
@@ -90,3 +98,4 @@ object-templates-raw: |
         nodeTopologies: {}
         externalStorage: {}
         resourceProfile: '{{hub index .ManagedClusterLabels "autoshift.io/odf-resource-profile" | default "balanced" hub}}'
+  {{hub- end hub}}

--- a/policies/stable/openshift-data-foundation/manifests/storage-cluster/storage-cluster.yaml
+++ b/policies/stable/openshift-data-foundation/manifests/storage-cluster/storage-cluster.yaml
@@ -1,6 +1,6 @@
 object-templates-raw: |
-  {{hub $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) hub}}
-  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml) hub}}
+  {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml | default dict) hub}}
   {{hub- $odf := (index $config "odf" | default dict) hub}}
   {{hub- $storageCluster := (index $odf "storageCluster" | default dict) hub}}
   - complianceType: musthave


### PR DESCRIPTION
## Summary

- Add rendered-config ConfigMap lookup to the ODF StorageCluster policy template so a custom `spec` can be provided via `config.odf.storageCluster` in values files. When a config block is present, it replaces the default label-driven spec entirely; otherwise the existing label-driven defaults apply unchanged.
- Convert the local-storage LocalVolumeSet manifest to `object-templates-raw` with rendered-config lookup. Supports optional `LocalVolumeDiscovery` and multiple `LocalVolumeSet` CRs keyed by name (e.g., nvme, ssd) via `config.localStorage`. Falls back to the original hardcoded `nvme-localvolumeset` when no config is present.
- Include an example clusterset values file (`non-ha-acps-odf-custom-example.yaml`) demonstrating multi-device-class storageDeviceSets and multi-volume-set local-storage configuration.

Both follow the existing config-driven pattern used by NMState and cert-manager (rendered-config ConfigMap lookup with fallback to label-driven defaults).

## Test plan

- [ ] Deploy with no `config.odf` or `config.localStorage` blocks — verify existing label-driven ODF StorageCluster and default nvme LocalVolumeSet are created unchanged
- [ ] Deploy with `config.odf.storageCluster` block — verify custom StorageCluster spec is applied
- [ ] Deploy with `config.localStorage.localVolumeSets` — verify multiple named LocalVolumeSets are created
- [ ] Deploy with `config.localStorage.localVolumeDiscovery` — verify LocalVolumeDiscovery CR is created
- [ ] Verify no regressions on clusters not using config blocks