### PR TITLE
feat: config-driven AAP instance spec via rendered-config

### DIFF
--- a/policies/stable/ansible-automation-platform/manifests/aap-instance.yaml
+++ b/policies/stable/ansible-automation-platform/manifests/aap-instance.yaml
@@ -1,4 +1,8 @@
 object-templates-raw: |
+  {{hub $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml) hub}}
+  {{hub- $aap := (index $config "aap" | default dict) hub}}
+  {{hub- $aapInstance := (index $aap "instance" | default dict) hub}}
   - complianceType: mustonlyhave
     objectDefinition:
       apiVersion: aap.ansible.com/v1alpha1
@@ -6,6 +10,10 @@ object-templates-raw: |
       metadata:
         name: "aap"
         namespace: "ansible-automation-platform"
+  {{hub- if (gt (len (keys $aapInstance)) 0) hub}}
+      spec:
+        {{hub $aapInstance | toYaml | autoindent hub}}
+  {{hub- else hub}}
       spec:
         controller:
           disabled: false
@@ -27,3 +35,4 @@ object-templates-raw: |
         {{hub- if or (eq (index .ManagedClusterLabels "autoshift.io/aap-noobaa-s3-storage" | default "false") "true") (eq (index .ManagedClusterLabels "autoshift.io/aap-custom-cabundle" | default "false") "true") hub}}
         bundle_cacert_secret: user-ca-bundle
         {{hub- end hub}}
+  {{hub- end hub}}


### PR DESCRIPTION
## Summary

- Add rendered-config ConfigMap lookup to the AAP AnsibleAutomationPlatform policy template so a custom spec can be provided via `config.aap.instance` in values files.
- When present, replaces the default label-driven spec entirely. When absent, the existing label-driven spec (controller/hub/eda/lightspeed toggles, S3 storage, CA bundle) continues to work unchanged.
- Follows the same config-driven pattern used by NMState, cert-manager, and ODF.

## Test plan

- [ ] Deploy with no `config.aap` block — verify existing label-driven AAP instance is created unchanged
- [x] Deploy with `config.aap.instance` block — verify custom AnsibleAutomationPlatform spec is applied
- [ ] Verify no regression on clusters not using config blocks

## Validation (2026-09-03, compact-acp cluster)

**Hub policy:** `policy-aap-instance` — Compliant on compact-acp
**Spoke resource:** `ansibleautomationplatforms [aap]` found as specified in namespace `ansible-automation-platform`

Config block used:
\`\`\`yaml
config.aap.instance:
  controller: { disabled: false }
  hub: { disabled: true }
  eda: { disabled: false }
  lightspeed: { disabled: true }
  redis_mode: standalone
  database: { postgres_storage_class: ocs-storagecluster-ceph-rbd }
\`\`\`