### PR TITLE
feat: add htpasswd identity provider policy

### DIFF
--- a/policies/stable/htpasswd/kustomization.yaml
+++ b/policies/stable/htpasswd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - policy-generator-config.yaml

--- a/policies/stable/htpasswd/manifests/htpasswd/htpasswd.yaml
+++ b/policies/stable/htpasswd/manifests/htpasswd/htpasswd.yaml
@@ -1,0 +1,61 @@
+# HTPasswd identity provider — creates Secrets + patches OAuth CR from config.htpasswd.
+#
+# Config (in rendered-config under htpasswd):
+#   providers[]           — list of identity providers to configure
+#     name                — display name shown on the login page (e.g. 'Cluster Admins')
+#     secretName          — Secret name in openshift-config (e.g. 'cluster-admins-htpass')
+#     htpasswd            — raw htpasswd file content (user:hash per line)
+#   clusterAdmins[]       — list of usernames to grant cluster-admin ClusterRoleBinding
+object-templates-raw: |
+  {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml | default dict) hub}}
+  {{hub- $htpasswdCfg := (index $config "htpasswd" | default dict) hub}}
+  {{hub- $providers := (index $htpasswdCfg "providers" | default list) hub}}
+  {{hub- $clusterAdmins := (index $htpasswdCfg "clusterAdmins" | default list) hub}}
+  {{hub- range $provider := $providers hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{hub $provider.secretName hub}}
+        namespace: openshift-config
+      type: Opaque
+      stringData:
+        htpasswd: |
+          {{hub $provider.htpasswd | trim | autoindent hub}}
+  {{hub- end hub}}
+  {{hub- if gt (len $providers) 0 hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+          {{hub- range $provider := $providers hub}}
+          - name: {{hub $provider.name hub}}
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: {{hub $provider.secretName hub}}
+          {{hub- end hub}}
+  {{hub- end hub}}
+  {{hub- range $admin := $clusterAdmins hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: autoshift-cluster-admin-{{hub $admin hub}}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: User
+          name: {{hub $admin hub}}
+  {{hub- end hub}}

--- a/policies/stable/htpasswd/placement.yaml
+++ b/policies/stable/htpasswd/placement.yaml
@@ -1,0 +1,19 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-htpasswd
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/htpasswd'
+              operator: In
+              values:
+                - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/stable/htpasswd/policy-generator-config.yaml
+++ b/policies/stable/htpasswd/policy-generator-config.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: htpasswd
+placementBindingDefaults:
+  name: binding-policy-htpasswd
+policyDefaults:
+  namespace: ${POLICY_NAMESPACE}
+  remediationAction: ${REMEDIATION}
+  severity: high
+  consolidateManifests: false
+  evaluationInterval:
+    compliant: ${EVAL_COMPLIANT}
+    noncompliant: ${EVAL_NONCOMPLIANT}
+  standards:
+    - NIST SP 800-53
+  categories:
+    - IA Identification and Authentication
+  controls:
+    - IA-2 Identification and Authentication
+  placement:
+    placementPath: placement.yaml
+policies:
+  - name: policy-htpasswd
+    manifests:
+      - path: manifests/htpasswd


### PR DESCRIPTION
## Summary

- Add a new `htpasswd` policy that configures HTPasswd identity providers on spoke clusters via config blocks in rendered-config ConfigMaps.
- Supports multiple named providers (each creates a Secret in `openshift-config` and patches the cluster OAuth CR).
- Supports an optional `clusterAdmins` list that creates `cluster-admin` ClusterRoleBindings.
- Gated by the `remove-kubeadmin: 'true'` label on ManagedClusters (intended to be deployed alongside kubeadmin removal).

## Test plan

- [x] Deploy with `config.htpasswd.providers` containing one provider — verify Secret and OAuth CR patch are created
- [ ] Deploy with multiple providers — verify all Secrets and all identity provider entries are added
- [x] Deploy with `config.htpasswd.clusterAdmins` — verify ClusterRoleBindings are created
- [ ] Deploy without any htpasswd config — verify policy is compliant with no objects created

## Validation (2026-09-03, compact-acp cluster)

**Hub policy:** `policy-htpasswd` — Compliant on compact-acp
**Spoke resources:**
- Secret `test-admins-htpass` found as specified in namespace `openshift-config`
- OAuth CR `cluster` found as specified (identity provider patched)
- ClusterRoleBinding `autoshift-cluster-admin-testuser` found as specified

Config block used:
\`\`\`yaml
config.htpasswd:
  providers:
    - name: Test Admins
      secretName: test-admins-htpass
      htpasswd: "testuser:\$apr1\$..."
  clusterAdmins:
    - testuser
\`\`\`