### PR TITLE
feat: add remove-kubeadmin policy

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -1244,6 +1244,11 @@ hubClusterSets:
       # dbBackupSchedule, dbBackupRetention
 
       # =======================================================================
+      # Remove Kubeadmin
+      # =======================================================================
+      remove-kubeadmin: 'false'              # Remove kubeadmin secret (disables OAuth-based kubeadmin login)
+
+      # =======================================================================
       # Disconnected Mirror Settings
       # =======================================================================
       disconnected-mirror: 'false'           # Enable mirrored catalog sources

--- a/policies/stable/remove-kubeadmin/kustomization.yaml
+++ b/policies/stable/remove-kubeadmin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - policy-generator-config.yaml

--- a/policies/stable/remove-kubeadmin/manifests/remove-kubeadmin/remove-kubeadmin.yaml
+++ b/policies/stable/remove-kubeadmin/manifests/remove-kubeadmin/remove-kubeadmin.yaml
@@ -1,0 +1,7 @@
+- complianceType: mustnothave
+  objectDefinition:
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kubeadmin
+      namespace: kube-system

--- a/policies/stable/remove-kubeadmin/manifests/remove-kubeadmin/remove-kubeadmin.yaml
+++ b/policies/stable/remove-kubeadmin/manifests/remove-kubeadmin/remove-kubeadmin.yaml
@@ -1,7 +1,8 @@
-- complianceType: mustnothave
-  objectDefinition:
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: kubeadmin
-      namespace: kube-system
+object-templates-raw: |
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kubeadmin
+        namespace: kube-system

--- a/policies/stable/remove-kubeadmin/placement.yaml
+++ b/policies/stable/remove-kubeadmin/placement.yaml
@@ -1,0 +1,19 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-remove-kubeadmin
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/remove-kubeadmin'
+              operator: In
+              values:
+                - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/stable/remove-kubeadmin/policy-generator-config.yaml
+++ b/policies/stable/remove-kubeadmin/policy-generator-config.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: remove-kubeadmin
+placementBindingDefaults:
+  name: binding-policy-remove-kubeadmin
+policyDefaults:
+  namespace: ${POLICY_NAMESPACE}
+  remediationAction: ${REMEDIATION}
+  severity: high
+  consolidateManifests: false
+  evaluationInterval:
+    compliant: ${EVAL_COMPLIANT}
+    noncompliant: ${EVAL_NONCOMPLIANT}
+  standards:
+    - NIST SP 800-53
+  categories:
+    - IA Identification and Authentication
+  controls:
+    - IA-2 Identification and Authentication
+  placement:
+    placementPath: placement.yaml
+policies:
+  - name: policy-remove-kubeadmin
+    manifests:
+      - path: manifests/remove-kubeadmin


### PR DESCRIPTION
## Summary

- Add a new `remove-kubeadmin` policy that ensures the `kubeadmin` Secret in `kube-system` does not exist on spoke clusters.
- Uses `mustnothave` compliance type with `object-templates-raw` to enforce removal.
- Gated by the `remove-kubeadmin: 'true'` label on ManagedClusters.
- Should be deployed after an alternative identity provider (e.g., htpasswd, LDAP) is configured to avoid locking out cluster access.

## Test plan

- [x] Deploy with `remove-kubeadmin: 'true'` label — verify kubeadmin Secret is removed
- [ ] Deploy without the label — verify policy does not target the cluster
- [ ] Verify no impact on clusters that have already had kubeadmin removed

## Validation (2026-09-03, compact-acp cluster)

**Hub policy:** `policy-remove-kubeadmin` — Compliant on compact-acp
**Spoke resource:** Secret `kubeadmin` missing as expected in namespace `kube-system`