### PR TITLE
feat: add gitops console plugin policy

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -684,6 +684,7 @@ hubClusterSets:
       gitops-source-namespace: openshift-marketplace
       gitops-namespace: 'openshift-gitops'          # Override ArgoCD namespace per-cluster
       gitops-cluster-ca-bundle: 'true'              # Inject cluster trusted CA bundle into ArgoCD repo server
+      gitops-console-plugin: 'false'                  # GitOps console plugin (tech preview) — adds ArgoCD to OCP console
 
       # =======================================================================
       # AutoShift Console Plugin (hub only — reads hub-side AutoShift ConfigMaps)

--- a/policies/stable/openshift-gitops/templates/policy-gitops-console-plugin.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-console-plugin.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.hubClusterSets }}
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-gitops-console-plugin
+  namespace: {{ .Values.policy_namespace }}
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+{{ if (($.Values.autoshift).dryRun) }}
+  remediationAction: inform
+{{ end }}
+  disabled: false
+  dependencies:
+    - name: policy-gitops-systems-argocd
+      namespace: {{ .Values.policy_namespace }}
+      apiVersion: policy.open-cluster-management.io/v1
+      compliance: Compliant
+      kind: Policy
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gitops-console-plugin
+        spec:
+          remediationAction: enforce
+          severity: high
+          evaluationInterval:
+            compliant: {{ ((($.Values.autoshift).evaluationInterval).compliant) | default "10m" }}
+            noncompliant: {{ ((($.Values.autoshift).evaluationInterval).noncompliant) | default "30s" }}
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operator.openshift.io/v1
+                kind: Console
+                metadata:
+                  name: cluster
+                spec:
+                  plugins:
+                    - gitops-plugin
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: policy-gitops-console-plugin-placement
+  namespace: {{ .Values.policy_namespace }}
+spec:
+  clusterSets:
+  {{- range $clusterSet, $value := .Values.hubClusterSets }}
+    - {{ $clusterSet }}
+  {{- end }}
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: policy-gitops-console-plugin-placement
+  namespace: {{ .Values.policy_namespace }}
+placementRef:
+  name: policy-gitops-console-plugin-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+subjects:
+  - name: policy-gitops-console-plugin
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy
+{{- end }}

--- a/policies/stable/openshift-gitops/templates/policy-gitops-console-plugin.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-console-plugin.yaml
@@ -53,6 +53,14 @@ spec:
   {{- range $clusterSet, $value := .Values.hubClusterSets }}
     - {{ $clusterSet }}
   {{- end }}
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/gitops-console-plugin'
+              operator: In
+              values:
+                - 'true'
   tolerations:
     - key: cluster.open-cluster-management.io/unreachable
       operator: Exists


### PR DESCRIPTION
## Summary

- Add a new policy `policy-gitops-console-plugin` to the `openshift-gitops` policy set that enables the GitOps console plugin on hub clusters.
- Creates a `Console` CR patch to register the `gitops-plugin` plugin, making ArgoCD/GitOps visible in the OpenShift web console.
- Depends on `policy-gitops-systems-argocd` (waits for the ArgoCD instance to be ready before enabling the plugin).
- Deployed to hub clusters only (gated by `hubClusterSets`).

## Test plan

- [ ] Deploy on a hub cluster — verify the gitops console plugin appears in the OpenShift web console
- [x] Verify dependency on `policy-gitops-systems-argocd` — plugin policy should wait until ArgoCD is compliant
- [ ] Verify no impact on spoke clusters (policy should not be created when `hubClusterSets` is empty)

## Validation (2026-09-03, hub cluster)

**Hub policy:** `policy-gitops-console-plugin` — placed on `local-cluster` via `hubClusterSets`
**Dependency:** `policy-gitops-systems-argocd` is Compliant
**Note:** Policy was propagated to `local-cluster` but compliance not evaluated — test hub's `local-cluster` ManagedCluster has `HUB ACCEPTED: false`, preventing policy enforcement. Policy definition and placement are correct; enforcement requires a fully self-managed hub.

**Local render (Tier 1):** PolicyGenerator renders cleanly — Console CR patch registers `gitops-plugin`.