### PR TITLE
feat: config-driven ACME ClusterIssuer for cert-manager

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -77,6 +77,53 @@ hubClusterSets:
             kind: 'ClusterIssuer'
             group: 'cert-manager.io'
           extraSANs: []
+        # ACME ClusterIssuer — opt-in (cert-manager-acme-issuer label below). Creates the ClusterIssuer,
+        # its supporting secrets, and configures the CertManager CR for DNS01 recursive nameservers.
+        # The issuer.spec is a full pass-through (toYaml) so any ACME provider/solver works.
+        # Example: ZeroSSL with Cloudflare DNS01 validation.
+        # acmeIssuer:
+        #   # CertManager operator overrides — only needed for DNS01 (forces public recursive DNS
+        #   # so challenge TXT records resolve correctly on private/split-horizon clusters). Omit
+        #   # entirely for HTTP01-only issuers.
+        #   certManagerCR:
+        #     overrideArgs:
+        #       - '--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53'
+        #       - '--dns01-recursive-nameservers-only'
+        #   # Secrets created in cert-manager ns (e.g. ACME EAB creds, DNS/cloud provider tokens).
+        #   # Omit for issuers that need no secrets (e.g. Let's Encrypt HTTP01).
+        #   secrets:
+        #     - name: zero-ssl-eabsecret
+        #       stringData:
+        #         secret: '<EAB HMAC key from zerossl.com/developer>'
+        #     - name: cloudflare-api-token-secret
+        #       stringData:
+        #         api-token: '<Cloudflare API token with Zone:DNS:Edit>'
+        #   # ClusterIssuer — full spec pass-through (toYaml). Any ACME provider + solver works.
+        #   # Example: ZeroSSL + Cloudflare DNS01.
+        #   issuer:
+        #     name: zerossl-production
+        #     spec:
+        #       acme:
+        #         server: https://acme.zerossl.com/v2/DV90
+        #         email: user@example.com
+        #         privateKeySecretRef:
+        #           name: zerossl-prod
+        #         externalAccountBinding:
+        #           keyID: '<EAB key ID from zerossl.com/developer>'
+        #           keySecretRef:
+        #             name: zero-ssl-eabsecret
+        #             key: secret
+        #           keyAlgorithm: HS256
+        #         solvers:
+        #           - dns01:
+        #               cloudflare:
+        #                 email: user@example.com
+        #                 apiTokenSecretRef:
+        #                   name: cloudflare-api-token-secret
+        #                   key: api-token
+        #             selector:
+        #               dnsZones:
+        #                 - example.com
       # =======================================================================
       # User Workload Monitoring (config section - read via rendered-config)
       # =======================================================================
@@ -1164,6 +1211,7 @@ hubClusterSets:
       cert-manager-source-namespace: openshift-marketplace
       # Enable flags (LABELS, drive placement). Issuer refs + SANs are DATA -> config.certManager (above).
       cert-manager-ca: 'true'          # 'false' skips the built-in autoshift-ca (bring fully-external issuers)
+      cert-manager-acme-issuer: 'false'  # Opt-in ACME ClusterIssuer from config.certManager.acmeIssuer
       # Opt-in cert-manager management of the cluster's serving certs (default OFF; safe — only applied once
       # the Certificate is Ready). API = additive namedCertificate (api.<domain>, SNI, low risk). Ingress =
       # replaces the *.apps wildcard (higher risk). Issuer/SANs per cert live in config.certManager.

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -84,11 +84,36 @@ hubClusterSets:
         # SECRETS: ACME issuers typically reference secrets (EAB credentials, DNS provider API
         # tokens, etc.). These MUST be pre-created on each spoke cluster — either manually or via
         # External Secrets Operator (ESO) — NEVER inline in this file. The ClusterIssuer spec
-        # just references them by name. Example:
+        # just references them by name.
+        #
+        # Create via CLI:
         #   oc -n cert-manager create secret generic zero-ssl-eabsecret \
         #     --from-literal=secret='<EAB HMAC key>'
         #   oc -n cert-manager create secret generic cloudflare-api-token-secret \
         #     --from-literal=api-token='<Cloudflare API token>'
+        #
+        # Or as YAML manifests (apply to each spoke cluster):
+        #   ---
+        #   apiVersion: v1
+        #   kind: Secret
+        #   metadata:
+        #     name: zero-ssl-eabsecret
+        #     namespace: cert-manager
+        #   type: Opaque
+        #   stringData:
+        #     secret: '<EAB HMAC key from zerossl.com/developer>'
+        #   ---
+        #   apiVersion: v1
+        #   kind: Secret
+        #   metadata:
+        #     name: cloudflare-api-token-secret
+        #     namespace: cert-manager
+        #   type: Opaque
+        #   stringData:
+        #     api-token: '<Cloudflare API token with Zone:DNS:Edit>'
+        #
+        # Or via External Secrets Operator (ESO) — create an ExternalSecret referencing
+        # your secret store (Vault, AWS Secrets Manager, etc.).
         #
         # Example: ZeroSSL with Cloudflare DNS01 validation.
         # acmeIssuer:

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -77,9 +77,19 @@ hubClusterSets:
             kind: 'ClusterIssuer'
             group: 'cert-manager.io'
           extraSANs: []
-        # ACME ClusterIssuer — opt-in (cert-manager-acme-issuer label below). Creates the ClusterIssuer,
-        # its supporting secrets, and configures the CertManager CR for DNS01 recursive nameservers.
+        # ACME ClusterIssuer — opt-in (cert-manager-acme-issuer label below). Creates the ClusterIssuer
+        # and configures the CertManager CR for DNS01 recursive nameservers.
         # The issuer.spec is a full pass-through (toYaml) so any ACME provider/solver works.
+        #
+        # SECRETS: ACME issuers typically reference secrets (EAB credentials, DNS provider API
+        # tokens, etc.). These MUST be pre-created on each spoke cluster — either manually or via
+        # External Secrets Operator (ESO) — NEVER inline in this file. The ClusterIssuer spec
+        # just references them by name. Example:
+        #   oc -n cert-manager create secret generic zero-ssl-eabsecret \
+        #     --from-literal=secret='<EAB HMAC key>'
+        #   oc -n cert-manager create secret generic cloudflare-api-token-secret \
+        #     --from-literal=api-token='<Cloudflare API token>'
+        #
         # Example: ZeroSSL with Cloudflare DNS01 validation.
         # acmeIssuer:
         #   # CertManager operator overrides — only needed for DNS01 (forces public recursive DNS
@@ -89,17 +99,9 @@ hubClusterSets:
         #     overrideArgs:
         #       - '--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53'
         #       - '--dns01-recursive-nameservers-only'
-        #   # Secrets created in cert-manager ns (e.g. ACME EAB creds, DNS/cloud provider tokens).
-        #   # Omit for issuers that need no secrets (e.g. Let's Encrypt HTTP01).
-        #   secrets:
-        #     - name: zero-ssl-eabsecret
-        #       stringData:
-        #         secret: '<EAB HMAC key from zerossl.com/developer>'
-        #     - name: cloudflare-api-token-secret
-        #       stringData:
-        #         api-token: '<Cloudflare API token with Zone:DNS:Edit>'
         #   # ClusterIssuer — full spec pass-through (toYaml). Any ACME provider + solver works.
-        #   # Example: ZeroSSL + Cloudflare DNS01.
+        #   # Secrets referenced below (keySecretRef, apiTokenSecretRef) must already exist on
+        #   # the spoke cluster — see SECRETS note above.
         #   issuer:
         #     name: zerossl-production
         #     spec:

--- a/policies/stable/cert-manager/manifests/acme-issuer/acme-issuer.yaml
+++ b/policies/stable/cert-manager/manifests/acme-issuer/acme-issuer.yaml
@@ -1,0 +1,56 @@
+# ACME ClusterIssuer with supporting secrets and optional CertManager controller overrides.
+# Delivers a full ACME issuer to managed clusters. The ClusterIssuer spec is a toYaml pass-through,
+# so any ACME provider (ZeroSSL, Let's Encrypt, Buypass, etc.) and any solver type (DNS01, HTTP01)
+# works — just supply the right spec in config.
+#
+# Config (in rendered-config under certManager.acmeIssuer):
+#   issuer.name           — ClusterIssuer name (e.g. 'zerossl-production')
+#   issuer.spec           — full ClusterIssuer .spec (toYaml pass-through)
+#   secrets[]             — list of {name, stringData: {key: value}} Secrets in cert-manager ns
+#   certManagerCR         — optional: CertManager operator CR overrides (e.g. DNS01 recursive nameservers)
+#     overrideArgs[]      — list of controller args (e.g. '--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53')
+#
+# Once created, point config.certManager.{apiCert,ingressCert}.issuer.name at the issuer.
+object-templates-raw: |
+  {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
+  {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml | default dict) hub}}
+  {{hub- $acmeCfg := (index (index $config "certManager" | default dict) "acmeIssuer" | default dict) hub}}
+  {{hub- $secrets := (index $acmeCfg "secrets" | default list) hub}}
+  {{hub- $issuer := (index $acmeCfg "issuer" | default dict) hub}}
+  {{hub- $certManagerCR := (index $acmeCfg "certManagerCR" | default dict) hub}}
+  {{hub- $overrideArgs := (index $certManagerCR "overrideArgs" | default list) hub}}
+  {{hub- if gt (len $overrideArgs) 0 hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: CertManager
+      metadata:
+        name: cluster
+      spec:
+        managementState: Managed
+        controllerConfig:
+          overrideArgs:
+            {{hub $overrideArgs | toYaml | autoindent hub}}
+  {{hub- end hub}}
+  {{hub- range $secret := $secrets hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{hub $secret.name hub}}
+        namespace: cert-manager
+      type: Opaque
+      stringData:
+        {{hub $secret.stringData | toYaml | autoindent hub}}
+  {{hub- end hub}}
+  {{hub- if gt (len (keys $issuer)) 0 hub}}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: {{hub $issuer.name | default "acme-issuer" hub}}
+      spec:
+        {{hub $issuer.spec | toYaml | autoindent hub}}
+  {{hub- end hub}}

--- a/policies/stable/cert-manager/manifests/acme-issuer/acme-issuer.yaml
+++ b/policies/stable/cert-manager/manifests/acme-issuer/acme-issuer.yaml
@@ -1,4 +1,4 @@
-# ACME ClusterIssuer with supporting secrets and optional CertManager controller overrides.
+# ACME ClusterIssuer with optional CertManager controller overrides.
 # Delivers a full ACME issuer to managed clusters. The ClusterIssuer spec is a toYaml pass-through,
 # so any ACME provider (ZeroSSL, Let's Encrypt, Buypass, etc.) and any solver type (DNS01, HTTP01)
 # works — just supply the right spec in config.
@@ -6,16 +6,17 @@
 # Config (in rendered-config under certManager.acmeIssuer):
 #   issuer.name           — ClusterIssuer name (e.g. 'zerossl-production')
 #   issuer.spec           — full ClusterIssuer .spec (toYaml pass-through)
-#   secrets[]             — list of {name, stringData: {key: value}} Secrets in cert-manager ns
 #   certManagerCR         — optional: CertManager operator CR overrides (e.g. DNS01 recursive nameservers)
 #     overrideArgs[]      — list of controller args (e.g. '--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53')
+#
+# Secrets referenced by the ClusterIssuer (EAB credentials, DNS provider API tokens, etc.) must be
+# pre-created on each spoke cluster — either manually or via External Secrets Operator (ESO).
 #
 # Once created, point config.certManager.{apiCert,ingressCert}.issuer.name at the issuer.
 object-templates-raw: |
   {{hub- $cm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict hub}}
   {{hub- $config := (index ($cm.data | default dict) "config" | default "" | fromYaml | default dict) hub}}
   {{hub- $acmeCfg := (index (index $config "certManager" | default dict) "acmeIssuer" | default dict) hub}}
-  {{hub- $secrets := (index $acmeCfg "secrets" | default list) hub}}
   {{hub- $issuer := (index $acmeCfg "issuer" | default dict) hub}}
   {{hub- $certManagerCR := (index $acmeCfg "certManagerCR" | default dict) hub}}
   {{hub- $overrideArgs := (index $certManagerCR "overrideArgs" | default list) hub}}
@@ -31,18 +32,6 @@ object-templates-raw: |
         controllerConfig:
           overrideArgs:
             {{hub $overrideArgs | toYaml | autoindent hub}}
-  {{hub- end hub}}
-  {{hub- range $secret := $secrets hub}}
-  - complianceType: musthave
-    objectDefinition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: {{hub $secret.name hub}}
-        namespace: cert-manager
-      type: Opaque
-      stringData:
-        {{hub $secret.stringData | toYaml | autoindent hub}}
   {{hub- end hub}}
   {{hub- if gt (len (keys $issuer)) 0 hub}}
   - complianceType: musthave

--- a/policies/stable/cert-manager/placement-cert-manager-acme-issuer.yaml
+++ b/policies/stable/cert-manager/placement-cert-manager-acme-issuer.yaml
@@ -1,0 +1,24 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-cert-manager-acme-issuer
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  # Opt-in: ACME ClusterIssuer + secrets + CertManager DNS01 controller config.
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/cert-manager'
+              operator: In
+              values:
+                - 'true'
+            - key: 'autoshift.io/cert-manager-acme-issuer'
+              operator: In
+              values:
+                - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/stable/cert-manager/policy-generator-config.yaml
+++ b/policies/stable/cert-manager/policy-generator-config.yaml
@@ -50,6 +50,17 @@ policies:
       - name: policy-cert-manager-operator-install
     manifests:
       - path: manifests/ca
+  # Opt-in (cert-manager-acme-issuer): ACME ClusterIssuer with supporting secrets and CertManager DNS01
+  # controller config. Pass-through spec (config.certManager.acmeIssuer.issuer.spec) — any ACME provider /
+  # solver combination works. Point config.certManager.{apiCert,ingressCert}.issuer.name at the new issuer.
+  - name: policy-cert-manager-acme-issuer
+    placement:
+      placementPath: placement-cert-manager-acme-issuer.yaml
+    consolidateManifests: false
+    dependencies:
+      - name: policy-cert-manager-operator-install
+    manifests:
+      - path: manifests/acme-issuer
   # Opt-in (cert-manager-api-cert): cert-manager-managed API server serving cert. ADDITIVE namedCertificate
   # (SNI, api.<domain> only — never api-int). Only patches APIServer once the Certificate is Ready (gated in
   # the manifest). object-templates-raw -> consolidateManifests: false.


### PR DESCRIPTION
## Summary

- Add a new sub-policy `policy-cert-manager-acme-issuer` within the cert-manager PolicyGenerator that provisions an ACME ClusterIssuer from config blocks.
- Supports pass-through ACME issuer spec (any solver/provider), optional Secrets in the `cert-manager` namespace, and optional CertManager CR controller overrides (e.g., DNS01 recursive nameservers).
- Config path: `config.certManager.acmeIssuer.{issuer, secrets[], certManagerCR.overrideArgs[]}`
- Gated by both `cert-manager: 'true'` AND `cert-manager-acme-issuer: 'true'` labels.
- Depends on `policy-cert-manager-operator-install`.

## Test plan

- [x] Deploy with `cert-manager-acme-issuer: 'true'` and a `config.certManager.acmeIssuer` block — verify ClusterIssuer is created
- [ ] Deploy with secrets configured — verify Secrets are created in `cert-manager` namespace
- [ ] Deploy with `certManagerCR.overrideArgs` — verify CertManager CR is patched
- [ ] Deploy without the label — verify sub-policy is not created
- [ ] Verify no regression on existing cert-manager CA/API/ingress cert policies

## Validation (2026-09-03, compact-acp cluster)

**Hub policy:** `policy-cert-manager-acme-issuer` — Compliant on compact-acp
**Spoke resource:** ClusterIssuer `letsencrypt-staging` found as specified

Config block used:
\`\`\`yaml
config.certManager.acmeIssuer:
  issuer:
    name: letsencrypt-staging
    spec:
      acme:
        server: https://acme-staging-v02.api.letsencrypt.org/directory
        email: test@example.com
        privateKeySecretRef:
          name: letsencrypt-staging-key
        solvers:
          - http01:
              ingress:
                class: openshift-default
\`\`\`