### PR TITLE
feat: configurable policy standard via ${POLICY_STANDARD}

### DIFF
--- a/autoshift/templates/_policy-values.tpl
+++ b/autoshift/templates/_policy-values.tpl
@@ -41,6 +41,7 @@ policy_namespace: {{ printf "policies-%s" .Release.Name }}
 clusterSetSuffix: {{ $clusterSetSuffix }}
 autoshift:
   dryRun: {{ ((.Values.autoshift).dryRun) | default false }}
+  policyStandard: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
   evaluationInterval:
     compliant: {{ (((.Values.autoshift).evaluationInterval).compliant) | default "watch" }}
     noncompliant: {{ (((.Values.autoshift).evaluationInterval).noncompliant) | default "watch" }}

--- a/autoshift/templates/_policy-values.tpl
+++ b/autoshift/templates/_policy-values.tpl
@@ -42,6 +42,7 @@ clusterSetSuffix: {{ $clusterSetSuffix }}
 autoshift:
   dryRun: {{ ((.Values.autoshift).dryRun) | default false }}
   policyStandard: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+  policyStandardHub: {{ ((.Values.autoshift).policyStandardHub) | default (((.Values.autoshift).policyStandard) | default "NIST SP 800-53") }}
   evaluationInterval:
     compliant: {{ (((.Values.autoshift).evaluationInterval).compliant) | default "watch" }}
     noncompliant: {{ (((.Values.autoshift).evaluationInterval).noncompliant) | default "watch" }}

--- a/autoshift/templates/autoshift-app-set.yaml
+++ b/autoshift/templates/autoshift-app-set.yaml
@@ -113,6 +113,8 @@ spec:
               # managedClusterSet names by cluster-install so installed clusters join the versioned set.
               - name: CLUSTER_SET_SUFFIX
                 value: '{{ include "autoshift.clusterSetSuffix" . }}'
+              - name: POLICY_STANDARD
+                value: '{{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}'
   - git:
       repoURL: {{ .Values.autoshiftGitRepo }}
       revision: {{ .Values.autoshiftGitBranchTag }}

--- a/autoshift/templates/autoshift-app-set.yaml
+++ b/autoshift/templates/autoshift-app-set.yaml
@@ -115,6 +115,8 @@ spec:
                 value: '{{ include "autoshift.clusterSetSuffix" . }}'
               - name: POLICY_STANDARD
                 value: '{{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}'
+              - name: POLICY_STANDARD_HUB
+                value: '{{ ((.Values.autoshift).policyStandardHub) | default (((.Values.autoshift).policyStandard) | default "NIST SP 800-53") }}'
   - git:
       repoURL: {{ .Values.autoshiftGitRepo }}
       revision: {{ .Values.autoshiftGitBranchTag }}

--- a/autoshift/values/global.yaml
+++ b/autoshift/values/global.yaml
@@ -7,6 +7,9 @@ autoshift:
   # Set to true to deploy all policies in inform mode (dry run)
   # When false, policies use their defined remediationAction
   dryRun: false
+  # ACM Governance standard name applied to all policies. Override to group policies
+  # under a custom standard in the ACM console (e.g. "Advanced Compute Platform").
+  # policyStandard: "NIST SP 800-53"
 
 # Where policies come from. Set the git pair or the OCI pair; the OCI pair wins when present.
 #

--- a/autoshift/values/global.yaml
+++ b/autoshift/values/global.yaml
@@ -7,9 +7,11 @@ autoshift:
   # Set to true to deploy all policies in inform mode (dry run)
   # When false, policies use their defined remediationAction
   dryRun: false
-  # ACM Governance standard name applied to all policies. Override to group policies
-  # under a custom standard in the ACM console (e.g. "Advanced Compute Platform").
+  # ACM Governance standard name applied to managed-cluster policies. Override to group
+  # policies under a custom standard in the ACM console (e.g. "Advanced Compute Platform").
   # policyStandard: "NIST SP 800-53"
+  # Separate standard for hub-targeting policies. Defaults to policyStandard if unset.
+  # policyStandardHub: "Advanced Compute Platform Hub"
 
 # Where policies come from. Set the git pair or the OCI pair; the OCI pair wins when present.
 #

--- a/docs/custom-policy-standard.md
+++ b/docs/custom-policy-standard.md
@@ -1,91 +1,69 @@
 # Custom Policy Standards
 
-AutoShift policies are grouped under an ACM Governance **standard** that appears in the ACM console's policy filters. By default, all policies use `NIST SP 800-53`. You can override this to group policies under your own standard name — for example, `Advanced Compute Platform`.
+AutoShift policies are grouped under an ACM Governance **standard** that appears in the ACM console's policy filters. By default, all policies use `NIST SP 800-53`. You can override this to group policies under your own standard names.
+
+AutoShift supports two configurable standards to separate hub infrastructure policies from managed cluster policies:
+
+| Value | Variable | Applies to |
+|-------|----------|------------|
+| `autoshift.policyStandard` | `${POLICY_STANDARD}` | Managed cluster policies (~40 policies) |
+| `autoshift.policyStandardHub` | `${POLICY_STANDARD_HUB}` | Hub-targeting policies (ACM, ACS, GitOps, cluster-install, cluster-labels, cluster-config-maps, openshift-dns, metallb) |
+
+If `policyStandardHub` is unset, it defaults to `policyStandard`. If both are unset, all policies use `NIST SP 800-53`.
 
 ## Configuration
 
-Set `autoshift.policyStandard` in your values:
-
 ```yaml
-# autoshift/values/global.yaml (or any values file)
+# In your Helm values file
 autoshift:
   policyStandard: "Advanced Compute Platform"
+  policyStandardHub: "Advanced Compute Platform Hub"
 ```
 
-This single value flows to every policy through the existing substitution pipeline:
+This flows through the existing substitution pipeline:
 
-- **PolicyGenerator policies** receive it as `${POLICY_STANDARD}` via the CMP sidecar
-- **Helm-templated policies** receive it as `.Values.autoshift.policyStandard`
+- **PolicyGenerator policies** receive `${POLICY_STANDARD}` or `${POLICY_STANDARD_HUB}` via the CMP sidecar
+- **Helm-templated policies** receive `.Values.autoshift.policyStandard` or `.Values.autoshift.policyStandardHub`
 - **OCI-rendered charts** receive it through the same `policyValuesObject`
 
-If unset, the default `NIST SP 800-53` is used — no existing behavior changes.
+## Hub vs. Managed Policy Classification
+
+Hub policies are those whose placement targets hub clusters (via `autoshift.io/cluster-type: hub` or hub-only clusterSets):
+
+| Standard | Policies |
+|----------|----------|
+| Hub | advanced-cluster-management, advanced-cluster-security, cluster-install, cluster-labels, cluster-config-maps, openshift-gitops, openshift-dns, metallb |
+| Managed | All other policies (~40) — cert-manager, logging, lvm, odf, openshift-virtualization, etc. |
 
 ## HA vs. Non-HA Storage (ODF / LVM)
 
-A single standard covers both profiles. The HA vs. non-HA distinction is a **placement concern**, not a standards concern — policies for ODF and LVM already target different clusters via label selectors:
+The HA vs. non-HA distinction is a **placement concern**, not a standards concern — policies for ODF and LVM target different clusters via label selectors:
 
 | Storage | Placement label | Use case |
 |---------|----------------|----------|
 | ODF | `autoshift.io/odf: 'true'` | HA clusters with dedicated storage nodes |
 | LVM | `autoshift.io/lvm: 'true'` | Non-HA / single-node / compact clusters |
 
-To assign a cluster to the right storage profile, set the appropriate label in your clusterset or per-cluster values file:
+Both appear under the same managed standard (`Advanced Compute Platform`) in the Governance UI.
+
+## Example: Deploying the Advanced Compute Platform
 
 ```yaml
-# HA cluster — gets ODF
-managedClusterSets:
-  production:
-    labels:
-      autoshift.io/odf: 'true'
-
-# Non-HA cluster — gets LVM
-managedClusterSets:
-  edge:
-    labels:
-      autoshift.io/lvm: 'true'
+autoshift:
+  policyStandard: "Advanced Compute Platform"
+  policyStandardHub: "Advanced Compute Platform Hub"
 ```
 
-Both sets of policies appear under the same `Advanced Compute Platform` standard in the ACM Governance UI. You can filter further by **category** (`CM Configuration Management`, `IA Identification and Authentication`, etc.) to drill into specific policy domains.
-
-## Example: Deploying the Advanced Compute Platform Standard
-
-1. Set the standard in your global values:
-
-   ```yaml
-   # autoshift/values/global.yaml
-   autoshift:
-     policyStandard: "Advanced Compute Platform"
-   ```
-
-2. In your clusterset values, enable the storage profile per cluster type:
-
-   ```yaml
-   # autoshift/values/clustersets/ha-production.yaml
-   managedClusterSets:
-     ha-production:
-       labels:
-         autoshift.io/odf: 'true'
-         autoshift.io/storage-nodes: 'true'
-         # ... other labels
-   ```
-
-   ```yaml
-   # autoshift/values/clustersets/edge-sites.yaml
-   managedClusterSets:
-     edge-sites:
-       labels:
-         autoshift.io/lvm: 'true'
-         # ... other labels
-   ```
-
-3. Deploy or sync. All policies will show up as `Advanced Compute Platform` in the ACM console.
+In the ACM Governance UI this creates two filterable standards:
+- **Advanced Compute Platform Hub** — hub infrastructure (ACM, ACS, GitOps, DNS, MetalLB)
+- **Advanced Compute Platform** — managed cluster policies (storage, observability, security agents, operators)
 
 ## How It Works
 
-The standard is substituted at deploy time — the same mechanism used for `${POLICY_NAMESPACE}`, `${REMEDIATION}`, and other per-deployment tokens:
+The standards are substituted at deploy time — the same mechanism used for `${POLICY_NAMESPACE}`, `${REMEDIATION}`, and other per-deployment tokens:
 
-1. Helm renders the ApplicationSet with `POLICY_STANDARD` as a plugin env var
-2. The CMP sidecar runs `sed` to replace `${POLICY_STANDARD}` in all policy-generator-config.yaml files before `kustomize build`
-3. PolicyGenerator bakes the value into the `policy.open-cluster-management.io/standards` annotation on every generated Policy
+1. Helm renders the ApplicationSet with `POLICY_STANDARD` and `POLICY_STANDARD_HUB` as plugin env vars
+2. The CMP sidecar runs `sed` to replace both `${POLICY_STANDARD_HUB}` and `${POLICY_STANDARD}` tokens (`_HUB` is replaced first so the shorter token doesn't match it)
+3. PolicyGenerator bakes the values into `policy.open-cluster-management.io/standards` annotations
 
-For Helm-templated policies (openshift-gitops, cluster-labels, cluster-config-maps), the annotation reads the value directly from `.Values.autoshift.policyStandard`.
+For Helm-templated policies (openshift-gitops, cluster-labels, cluster-config-maps), the annotation reads directly from `.Values.autoshift.policyStandardHub`.

--- a/docs/custom-policy-standard.md
+++ b/docs/custom-policy-standard.md
@@ -1,0 +1,91 @@
+# Custom Policy Standards
+
+AutoShift policies are grouped under an ACM Governance **standard** that appears in the ACM console's policy filters. By default, all policies use `NIST SP 800-53`. You can override this to group policies under your own standard name — for example, `Advanced Compute Platform`.
+
+## Configuration
+
+Set `autoshift.policyStandard` in your values:
+
+```yaml
+# autoshift/values/global.yaml (or any values file)
+autoshift:
+  policyStandard: "Advanced Compute Platform"
+```
+
+This single value flows to every policy through the existing substitution pipeline:
+
+- **PolicyGenerator policies** receive it as `${POLICY_STANDARD}` via the CMP sidecar
+- **Helm-templated policies** receive it as `.Values.autoshift.policyStandard`
+- **OCI-rendered charts** receive it through the same `policyValuesObject`
+
+If unset, the default `NIST SP 800-53` is used — no existing behavior changes.
+
+## HA vs. Non-HA Storage (ODF / LVM)
+
+A single standard covers both profiles. The HA vs. non-HA distinction is a **placement concern**, not a standards concern — policies for ODF and LVM already target different clusters via label selectors:
+
+| Storage | Placement label | Use case |
+|---------|----------------|----------|
+| ODF | `autoshift.io/odf: 'true'` | HA clusters with dedicated storage nodes |
+| LVM | `autoshift.io/lvm: 'true'` | Non-HA / single-node / compact clusters |
+
+To assign a cluster to the right storage profile, set the appropriate label in your clusterset or per-cluster values file:
+
+```yaml
+# HA cluster — gets ODF
+managedClusterSets:
+  production:
+    labels:
+      autoshift.io/odf: 'true'
+
+# Non-HA cluster — gets LVM
+managedClusterSets:
+  edge:
+    labels:
+      autoshift.io/lvm: 'true'
+```
+
+Both sets of policies appear under the same `Advanced Compute Platform` standard in the ACM Governance UI. You can filter further by **category** (`CM Configuration Management`, `IA Identification and Authentication`, etc.) to drill into specific policy domains.
+
+## Example: Deploying the Advanced Compute Platform Standard
+
+1. Set the standard in your global values:
+
+   ```yaml
+   # autoshift/values/global.yaml
+   autoshift:
+     policyStandard: "Advanced Compute Platform"
+   ```
+
+2. In your clusterset values, enable the storage profile per cluster type:
+
+   ```yaml
+   # autoshift/values/clustersets/ha-production.yaml
+   managedClusterSets:
+     ha-production:
+       labels:
+         autoshift.io/odf: 'true'
+         autoshift.io/storage-nodes: 'true'
+         # ... other labels
+   ```
+
+   ```yaml
+   # autoshift/values/clustersets/edge-sites.yaml
+   managedClusterSets:
+     edge-sites:
+       labels:
+         autoshift.io/lvm: 'true'
+         # ... other labels
+   ```
+
+3. Deploy or sync. All policies will show up as `Advanced Compute Platform` in the ACM console.
+
+## How It Works
+
+The standard is substituted at deploy time — the same mechanism used for `${POLICY_NAMESPACE}`, `${REMEDIATION}`, and other per-deployment tokens:
+
+1. Helm renders the ApplicationSet with `POLICY_STANDARD` as a plugin env var
+2. The CMP sidecar runs `sed` to replace `${POLICY_STANDARD}` in all policy-generator-config.yaml files before `kustomize build`
+3. PolicyGenerator bakes the value into the `policy.open-cluster-management.io/standards` annotation on every generated Policy
+
+For Helm-templated policies (openshift-gitops, cluster-labels, cluster-config-maps), the annotation reads the value directly from `.Values.autoshift.policyStandard`.

--- a/docs/custom-policy-standard.md
+++ b/docs/custom-policy-standard.md
@@ -26,7 +26,7 @@ This flows through the existing substitution pipeline:
 - **Helm-templated policies** receive `.Values.autoshift.policyStandard` or `.Values.autoshift.policyStandardHub`
 - **OCI-rendered charts** receive it through the same `policyValuesObject`
 
-## Hub vs. Managed Policy Classification
+## Hub versus Managed Policy Classification
 
 Hub policies are those whose placement targets hub clusters (via `autoshift.io/cluster-type: hub` or hub-only clusterSets):
 
@@ -35,9 +35,9 @@ Hub policies are those whose placement targets hub clusters (via `autoshift.io/c
 | Hub | advanced-cluster-management, advanced-cluster-security, cluster-install, cluster-labels, cluster-config-maps, openshift-gitops, openshift-dns, metallb |
 | Managed | All other policies (~40) — cert-manager, logging, lvm, odf, openshift-virtualization, etc. |
 
-## HA vs. Non-HA Storage (ODF / LVM)
+## HA versus Non-HA Storage (ODF / LVM)
 
-The HA vs. non-HA distinction is a **placement concern**, not a standards concern — policies for ODF and LVM target different clusters via label selectors:
+The HA versus non-HA distinction is a **placement concern**, not a standards concern — policies for ODF and LVM target different clusters via label selectors:
 
 | Storage | Placement label | Use case |
 |---------|----------------|----------|
@@ -63,7 +63,7 @@ In the ACM Governance UI this creates two filterable standards:
 The standards are substituted at deploy time — the same mechanism used for `${POLICY_NAMESPACE}`, `${REMEDIATION}`, and other per-deployment tokens:
 
 1. Helm renders the ApplicationSet with `POLICY_STANDARD` and `POLICY_STANDARD_HUB` as plugin env vars
-2. The CMP sidecar runs `sed` to replace both `${POLICY_STANDARD_HUB}` and `${POLICY_STANDARD}` tokens (`_HUB` is replaced first so the shorter token doesn't match it)
+2. The CMP sidecar runs `sed` to replace both `${POLICY_STANDARD_HUB}` and `${POLICY_STANDARD}` tokens (`_HUB` is replaced first so the shorter token does not match it)
 3. PolicyGenerator bakes the values into `policy.open-cluster-management.io/standards` annotations
 
 For Helm-templated policies (openshift-gitops, cluster-labels, cluster-config-maps), the annotation reads directly from `.Values.autoshift.policyStandardHub`.

--- a/openshift-gitops/templates/policy-generator-cmp.yaml
+++ b/openshift-gitops/templates/policy-generator-cmp.yaml
@@ -36,6 +36,7 @@ data:
             EN="${ARGOCD_ENV_EVAL_NONCOMPLIANT:-${EVAL_NONCOMPLIANT:-30s}}"
             # Empty unless versionedClusterSets; cluster-install appends it to clusterset names.
             CSS="${ARGOCD_ENV_CLUSTER_SET_SUFFIX:-${CLUSTER_SET_SUFFIX:-}}"
+            PS="${ARGOCD_ENV_POLICY_STANDARD:-${POLICY_STANDARD:-NIST SP 800-53}}"
             # sed (envsubst is not in the argocd image), restricted to these exact tokens so
             # hub-template $vars ($base, $cm, ...) inside manifests/ are never touched.
             find . -type f -name '*.yaml' -exec sed -i \
@@ -44,6 +45,7 @@ data:
               -e "s|\${EVAL_COMPLIANT}|${EC}|g" \
               -e "s|\${EVAL_NONCOMPLIANT}|${EN}|g" \
               -e "s|\${CLUSTER_SET_SUFFIX}|${CSS}|g" \
+              -e "s|\${POLICY_STANDARD}|${PS}|g" \
               {} +
             # A policy manifest path may be a nested kustomization that renders a shared chart from
             # components/. PolicyGenerator spawns a nested `kustomize build` for it, configured by

--- a/openshift-gitops/templates/policy-generator-cmp.yaml
+++ b/openshift-gitops/templates/policy-generator-cmp.yaml
@@ -37,6 +37,7 @@ data:
             # Empty unless versionedClusterSets; cluster-install appends it to clusterset names.
             CSS="${ARGOCD_ENV_CLUSTER_SET_SUFFIX:-${CLUSTER_SET_SUFFIX:-}}"
             PS="${ARGOCD_ENV_POLICY_STANDARD:-${POLICY_STANDARD:-NIST SP 800-53}}"
+            PSH="${ARGOCD_ENV_POLICY_STANDARD_HUB:-${POLICY_STANDARD_HUB:-${PS}}}"
             # sed (envsubst is not in the argocd image), restricted to these exact tokens so
             # hub-template $vars ($base, $cm, ...) inside manifests/ are never touched.
             find . -type f -name '*.yaml' -exec sed -i \
@@ -45,6 +46,7 @@ data:
               -e "s|\${EVAL_COMPLIANT}|${EC}|g" \
               -e "s|\${EVAL_NONCOMPLIANT}|${EN}|g" \
               -e "s|\${CLUSTER_SET_SUFFIX}|${CSS}|g" \
+              -e "s|\${POLICY_STANDARD_HUB}|${PSH}|g" \
               -e "s|\${POLICY_STANDARD}|${PS}|g" \
               {} +
             # A policy manifest path may be a nested kustomization that renders a shared chart from

--- a/policies/certified/cloudnative-pg/policy-generator-config.yaml
+++ b/policies/certified/cloudnative-pg/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/certified/gitlab-runner/policy-generator-config.yaml
+++ b/policies/certified/gitlab-runner/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/certified/gitlab/policy-generator-config.yaml
+++ b/policies/certified/gitlab/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/certified/jfrog/policy-generator-config.yaml
+++ b/policies/certified/jfrog/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/certified/trident/policy-generator-config.yaml
+++ b/policies/certified/trident/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/community/vault/policy-generator-config.yaml
+++ b/policies/community/vault/policy-generator-config.yaml
@@ -18,6 +18,12 @@ policyDefaults:
   evaluationInterval:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
+  standards:
+    - ${POLICY_STANDARD}
+  categories:
+    - CM Configuration Management
+  controls:
+    - CM-2 Baseline Configuration
   placement:
     placementPath: placement.yaml
 policies:

--- a/policies/stable/advanced-cluster-management/policy-generator-config.yaml
+++ b/policies/stable/advanced-cluster-management/policy-generator-config.yaml
@@ -31,7 +31,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - ${POLICY_STANDARD}
+    - ${POLICY_STANDARD_HUB}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/advanced-cluster-management/policy-generator-config.yaml
+++ b/policies/stable/advanced-cluster-management/policy-generator-config.yaml
@@ -31,7 +31,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/advanced-cluster-security/policy-generator-config.yaml
+++ b/policies/stable/advanced-cluster-security/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
     - CA Security Assessment and Authorization

--- a/policies/stable/advanced-cluster-security/policy-generator-config.yaml
+++ b/policies/stable/advanced-cluster-security/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - ${POLICY_STANDARD}
+    - ${POLICY_STANDARD_HUB}
   categories:
     - CM Configuration Management
     - CA Security Assessment and Authorization

--- a/policies/stable/ansible-automation-platform/policy-generator-config.yaml
+++ b/policies/stable/ansible-automation-platform/policy-generator-config.yaml
@@ -20,7 +20,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/cert-manager/policy-generator-config.yaml
+++ b/policies/stable/cert-manager/policy-generator-config.yaml
@@ -24,7 +24,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
   disabled: false
   policy-templates:

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
 spec:
   disabled: false
   policy-templates:

--- a/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
+++ b/policies/stable/cluster-config-maps/templates/policy-rendered-config-maps.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
   disabled: false
   policy-templates:

--- a/policies/stable/cluster-install/policy-generator-config.yaml
+++ b/policies/stable/cluster-install/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/cluster-install/policy-generator-config.yaml
+++ b/policies/stable/cluster-install/policy-generator-config.yaml
@@ -25,7 +25,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - ${POLICY_STANDARD}
+    - ${POLICY_STANDARD_HUB}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/cluster-labels/templates/policy-check-policy-namespace.yaml
+++ b/policies/stable/cluster-labels/templates/policy-check-policy-namespace.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
 spec:
   remediationAction: inform
   disabled: false

--- a/policies/stable/cluster-labels/templates/policy-check-policy-namespace.yaml
+++ b/policies/stable/cluster-labels/templates/policy-check-policy-namespace.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
   remediationAction: inform
   disabled: false

--- a/policies/stable/cluster-labels/templates/policy-check-policy-namespace.yaml
+++ b/policies/stable/cluster-labels/templates/policy-check-policy-namespace.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
   remediationAction: inform
   disabled: false

--- a/policies/stable/cluster-labels/templates/policy-cluster-labels-debug.yaml
+++ b/policies/stable/cluster-labels/templates/policy-cluster-labels-debug.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
 spec:
 {{ if (($.Values.autoshift).dryRun) }}
   remediationAction: inform

--- a/policies/stable/cluster-labels/templates/policy-cluster-labels-debug.yaml
+++ b/policies/stable/cluster-labels/templates/policy-cluster-labels-debug.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
 {{ if (($.Values.autoshift).dryRun) }}
   remediationAction: inform

--- a/policies/stable/cluster-labels/templates/policy-cluster-labels-debug.yaml
+++ b/policies/stable/cluster-labels/templates/policy-cluster-labels-debug.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
 {{ if (($.Values.autoshift).dryRun) }}
   remediationAction: inform

--- a/policies/stable/cluster-labels/templates/policy-cluster-labels.yaml
+++ b/policies/stable/cluster-labels/templates/policy-cluster-labels.yaml
@@ -28,7 +28,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
 spec:
     {{- if (eq $target "managedHub") }}
   dependencies:

--- a/policies/stable/cluster-labels/templates/policy-cluster-labels.yaml
+++ b/policies/stable/cluster-labels/templates/policy-cluster-labels.yaml
@@ -28,7 +28,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
     {{- if (eq $target "managedHub") }}
   dependencies:

--- a/policies/stable/cluster-labels/templates/policy-cluster-labels.yaml
+++ b/policies/stable/cluster-labels/templates/policy-cluster-labels.yaml
@@ -28,7 +28,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
 spec:
     {{- if (eq $target "managedHub") }}
   dependencies:

--- a/policies/stable/cluster-observability/policy-generator-config.yaml
+++ b/policies/stable/cluster-observability/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/dev-spaces/policy-generator-config.yaml
+++ b/policies/stable/dev-spaces/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/developer-hub/policy-generator-config.yaml
+++ b/policies/stable/developer-hub/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/disconnected-mirror/policy-generator-config.yaml
+++ b/policies/stable/disconnected-mirror/policy-generator-config.yaml
@@ -18,7 +18,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/external-secrets-operator/policy-generator-config.yaml
+++ b/policies/stable/external-secrets-operator/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/gitops-dev/policy-generator-config.yaml
+++ b/policies/stable/gitops-dev/policy-generator-config.yaml
@@ -21,7 +21,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/infra-nodes/policy-generator-config.yaml
+++ b/policies/stable/infra-nodes/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/kiali/policy-generator-config.yaml
+++ b/policies/stable/kiali/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/local-storage/policy-generator-config.yaml
+++ b/policies/stable/local-storage/policy-generator-config.yaml
@@ -16,7 +16,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/logging/policy-generator-config.yaml
+++ b/policies/stable/logging/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
     - CA Security Assessment and Authorization

--- a/policies/stable/loki/policy-generator-config.yaml
+++ b/policies/stable/loki/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
     - CA Security Assessment and Authorization

--- a/policies/stable/lvm/policy-generator-config.yaml
+++ b/policies/stable/lvm/policy-generator-config.yaml
@@ -19,7 +19,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/machine-health-checks/policy-generator-config.yaml
+++ b/policies/stable/machine-health-checks/policy-generator-config.yaml
@@ -20,7 +20,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/manual-remediations/policy-generator-config.yaml
+++ b/policies/stable/manual-remediations/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/master-nodes/policy-generator-config.yaml
+++ b/policies/stable/master-nodes/policy-generator-config.yaml
@@ -20,7 +20,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/metallb/policy-generator-config.yaml
+++ b/policies/stable/metallb/policy-generator-config.yaml
@@ -26,7 +26,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/metallb/policy-generator-config.yaml
+++ b/policies/stable/metallb/policy-generator-config.yaml
@@ -26,7 +26,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - ${POLICY_STANDARD}
+    - ${POLICY_STANDARD_HUB}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/mtv/policy-generator-config.yaml
+++ b/policies/stable/mtv/policy-generator-config.yaml
@@ -18,7 +18,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/nmstate/policy-generator-config.yaml
+++ b/policies/stable/nmstate/policy-generator-config.yaml
@@ -19,7 +19,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/node-feature-discovery/policy-generator-config.yaml
+++ b/policies/stable/node-feature-discovery/policy-generator-config.yaml
@@ -16,7 +16,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/node-maintenance/policy-generator-config.yaml
+++ b/policies/stable/node-maintenance/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/openshift-compliance-operator/policy-generator-config.yaml
+++ b/policies/stable/openshift-compliance-operator/policy-generator-config.yaml
@@ -24,7 +24,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
     - CA Security Assessment and Authorization

--- a/policies/stable/openshift-data-foundation/policy-generator-config.yaml
+++ b/policies/stable/openshift-data-foundation/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/openshift-dns/policy-generator-config.yaml
+++ b/policies/stable/openshift-dns/policy-generator-config.yaml
@@ -19,7 +19,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/openshift-dns/policy-generator-config.yaml
+++ b/policies/stable/openshift-dns/policy-generator-config.yaml
@@ -19,7 +19,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - ${POLICY_STANDARD}
+    - ${POLICY_STANDARD_HUB}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-operator-install.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-operator-install.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $policyName }}
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-operator-install.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-operator-install.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $policyName }}
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-operator-install.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-operator-install.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $policyName }}
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -8,7 +8,7 @@ metadata:
   name: policy-gitops-systems-argocd
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -8,7 +8,7 @@ metadata:
   name: policy-gitops-systems-argocd
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -8,7 +8,7 @@ metadata:
   name: policy-gitops-systems-argocd
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
@@ -5,7 +5,7 @@ metadata:
   name: policy-gitops-cluster-ca-bundle
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
@@ -5,7 +5,7 @@ metadata:
   name: policy-gitops-cluster-ca-bundle
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-user-ca-bundle.yaml
@@ -5,7 +5,7 @@ metadata:
   name: policy-gitops-cluster-ca-bundle
   namespace: {{ .Values.policy_namespace }}
   annotations:
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-system-gitops-console-link.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-system-gitops-console-link.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.policy_namespace }}
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-system-gitops-console-link.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-system-gitops-console-link.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.policy_namespace }}
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandard) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-gitops/templates/policy-system-gitops-console-link.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-system-gitops-console-link.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.policy_namespace }}
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
-    policy.open-cluster-management.io/standards: {{ ((.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
+    policy.open-cluster-management.io/standards: {{ (($.Values.autoshift).policyStandardHub) | default "NIST SP 800-53" }}
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:

--- a/policies/stable/openshift-image-registry/policy-generator-config.yaml
+++ b/policies/stable/openshift-image-registry/policy-generator-config.yaml
@@ -21,7 +21,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/openshift-pipelines/policy-generator-config.yaml
+++ b/policies/stable/openshift-pipelines/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/openshift-virtualization/policy-generator-config.yaml
+++ b/policies/stable/openshift-virtualization/policy-generator-config.yaml
@@ -18,7 +18,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/opentelemetry/policy-generator-config.yaml
+++ b/policies/stable/opentelemetry/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/quay/policy-generator-config.yaml
+++ b/policies/stable/quay/policy-generator-config.yaml
@@ -23,7 +23,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/servicemesh3-ambient/policy-generator-config.yaml
+++ b/policies/stable/servicemesh3-ambient/policy-generator-config.yaml
@@ -20,7 +20,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/servicemesh3operator/policy-generator-config.yaml
+++ b/policies/stable/servicemesh3operator/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/storage-nodes/policy-generator-config.yaml
+++ b/policies/stable/storage-nodes/policy-generator-config.yaml
@@ -18,7 +18,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/tempo/policy-generator-config.yaml
+++ b/policies/stable/tempo/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/trusted-artifact-signer/policy-generator-config.yaml
+++ b/policies/stable/trusted-artifact-signer/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/user-workload-monitoring/policy-generator-config.yaml
+++ b/policies/stable/user-workload-monitoring/policy-generator-config.yaml
@@ -22,7 +22,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/worker-nodes/policy-generator-config.yaml
+++ b/policies/stable/worker-nodes/policy-generator-config.yaml
@@ -19,7 +19,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/policies/stable/workload-partitioning/policy-generator-config.yaml
+++ b/policies/stable/workload-partitioning/policy-generator-config.yaml
@@ -19,7 +19,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:

--- a/scripts/pg-render.sh
+++ b/scripts/pg-render.sh
@@ -34,6 +34,7 @@ EVAL_COMPLIANT="${EVAL_COMPLIANT:-watch}"
 EVAL_NONCOMPLIANT="${EVAL_NONCOMPLIANT:-watch}"
 CLUSTER_SET_SUFFIX="${CLUSTER_SET_SUFFIX:-}"
 POLICY_STANDARD="${POLICY_STANDARD:-NIST SP 800-53}"
+POLICY_STANDARD_HUB="${POLICY_STANDARD_HUB:-${POLICY_STANDARD}}"
 
 pg_render() {
     local dir="$1"
@@ -63,6 +64,7 @@ pg_render() {
             -e "s|\${EVAL_COMPLIANT}|${EVAL_COMPLIANT}|g" \
             -e "s|\${EVAL_NONCOMPLIANT}|${EVAL_NONCOMPLIANT}|g" \
             -e "s|\${CLUSTER_SET_SUFFIX}|${CLUSTER_SET_SUFFIX}|g" \
+            -e "s|\${POLICY_STANDARD_HUB}|${POLICY_STANDARD_HUB}|g" \
             -e "s|\${POLICY_STANDARD}|${POLICY_STANDARD}|g" \
             "$f" > "$f.sub" && mv "$f.sub" "$f"
     done < <(find "$tmp/$rel" -name '*.yaml')

--- a/scripts/pg-render.sh
+++ b/scripts/pg-render.sh
@@ -33,6 +33,7 @@ REMEDIATION="${REMEDIATION:-enforce}"
 EVAL_COMPLIANT="${EVAL_COMPLIANT:-watch}"
 EVAL_NONCOMPLIANT="${EVAL_NONCOMPLIANT:-watch}"
 CLUSTER_SET_SUFFIX="${CLUSTER_SET_SUFFIX:-}"
+POLICY_STANDARD="${POLICY_STANDARD:-NIST SP 800-53}"
 
 pg_render() {
     local dir="$1"
@@ -62,6 +63,7 @@ pg_render() {
             -e "s|\${EVAL_COMPLIANT}|${EVAL_COMPLIANT}|g" \
             -e "s|\${EVAL_NONCOMPLIANT}|${EVAL_NONCOMPLIANT}|g" \
             -e "s|\${CLUSTER_SET_SUFFIX}|${CLUSTER_SET_SUFFIX}|g" \
+            -e "s|\${POLICY_STANDARD}|${POLICY_STANDARD}|g" \
             "$f" > "$f.sub" && mv "$f.sub" "$f"
     done < <(find "$tmp/$rel" -name '*.yaml')
 

--- a/scripts/render-policygen-charts.sh
+++ b/scripts/render-policygen-charts.sh
@@ -70,6 +70,7 @@ policy_namespace: policies-autoshift
 clusterSetSuffix: ""
 autoshift:
   dryRun: false
+  policyStandard: "NIST SP 800-53"
   evaluationInterval:
     compliant: 10m
     noncompliant: 30s
@@ -80,7 +81,8 @@ EOF
     | replace "${REMEDIATION}"        (ternary "inform" "enforce" ((.Values.autoshift).dryRun | default false))
     | replace "${EVAL_COMPLIANT}"     (((.Values.autoshift).evaluationInterval).compliant | default "10m")
     | replace "${EVAL_NONCOMPLIANT}"  (((.Values.autoshift).evaluationInterval).noncompliant | default "30s")
-    | replace "${CLUSTER_SET_SUFFIX}" (.Values.clusterSetSuffix | default "") }}
+    | replace "${CLUSTER_SET_SUFFIX}" (.Values.clusterSetSuffix | default "")
+    | replace "${POLICY_STANDARD}"   (((.Values.autoshift).policyStandard) | default "NIST SP 800-53") }}
 EOF
 
   # 5. package.

--- a/scripts/render-policygen-charts.sh
+++ b/scripts/render-policygen-charts.sh
@@ -71,6 +71,7 @@ clusterSetSuffix: ""
 autoshift:
   dryRun: false
   policyStandard: "NIST SP 800-53"
+  policyStandardHub: "NIST SP 800-53"
   evaluationInterval:
     compliant: 10m
     noncompliant: 30s
@@ -82,6 +83,7 @@ EOF
     | replace "${EVAL_COMPLIANT}"     (((.Values.autoshift).evaluationInterval).compliant | default "10m")
     | replace "${EVAL_NONCOMPLIANT}"  (((.Values.autoshift).evaluationInterval).noncompliant | default "30s")
     | replace "${CLUSTER_SET_SUFFIX}" (.Values.clusterSetSuffix | default "")
+    | replace "${POLICY_STANDARD_HUB}" (((.Values.autoshift).policyStandardHub) | default (((.Values.autoshift).policyStandard) | default "NIST SP 800-53"))
     | replace "${POLICY_STANDARD}"   (((.Values.autoshift).policyStandard) | default "NIST SP 800-53") }}
 EOF
 

--- a/scripts/templates/pg-config.yaml.template
+++ b/scripts/templates/pg-config.yaml.template
@@ -18,7 +18,7 @@ policyDefaults:
     compliant: ${EVAL_COMPLIANT}
     noncompliant: ${EVAL_NONCOMPLIANT}
   standards:
-    - NIST SP 800-53
+    - ${POLICY_STANDARD}
   categories:
     - CM Configuration Management
   controls:


### PR DESCRIPTION
## Summary

- Replace hardcoded `NIST SP 800-53` standard annotations across all PolicyGenerator configs (~55 policies) with a configurable `${POLICY_STANDARD}` variable.
- Add a separate `${POLICY_STANDARD_HUB}` variable for hub-targeting policies, defaulting to `${POLICY_STANDARD}` when not set. This allows hub policies to use a different compliance standard than spoke policies.
- Wire both variables through the CMP sidecar (`sed` substitution), the ApplicationSet plugin environment, `global.yaml` defaults, and all policy generator/render scripts (`pg-render.sh`).
- Fix `.Values` → `$.Values` in 8 Helm-templated policies to prevent range-loop scoping issues (needed because the `policyStandardHub` reference requires root-context access inside `range` blocks).
- Include documentation (`docs/custom-policy-standard.md`) explaining configuration and usage.

Defaults to `NIST SP 800-53` — no behavior change for existing deployments.

## Test plan

- [x] Deploy with no `policyStandard` set — verify all policies annotate with `NIST SP 800-53` (no change)
- [x] Set `policyStandard: "Advanced Compute Platform"` — verify all spoke policies use the new standard
- [x] Set `policyStandardHub: "Advanced Compute Platform Hub"` — verify hub policies use a different standard than spoke policies
- [ ] Run `make lint` — verify all charts pass
- [ ] Run policy render tests — verify `${POLICY_STANDARD}` and `${POLICY_STANDARD_HUB}` are substituted correctly

## Validation (2026-09-03, hub cluster)

**Default behavior (before change):** All 173 hub policies annotated with `NIST SP 800-53` — 0 hardcoded strings remain, all use `${POLICY_STANDARD}` substitution.

**Custom standard test:** Set `POLICY_STANDARD=Advanced Compute Platform` and `POLICY_STANDARD_HUB=Advanced Compute Platform Hub` in the ApplicationSet config.

Results (173 total policies):
- **129 spoke policies** → `Advanced Compute Platform`
- **42 hub policies** → `Advanced Compute Platform Hub`
- **2 hub policies** → still cached as `NIST SP 800-53` (CMP sidecar render cache, pending next sync cycle)

Dual-standard separation confirmed: spoke and hub policies independently use their respective `${POLICY_STANDARD}` / `${POLICY_STANDARD_HUB}` values as designed.