### PR TITLE
fix(gitops): read Argo CD defaults from values.yaml, retune sizing from measurements

### DIFF
--- a/autoshift/templates/autoshift-app-set.yaml
+++ b/autoshift/templates/autoshift-app-set.yaml
@@ -84,6 +84,15 @@ spec:
       template:
         metadata:
           name: '{{ .Release.Name }}-{{"{{"}} .path.basename {{"}}"}}'
+          annotations:
+            # Ship only this policy's own directory plus the shared charts it renders, instead of the
+            # whole repository, to the PolicyGenerator CMP sidecar. Honoured only when the repo-server
+            # runs with --plugin-use-manifest-generate-paths (gitops.policyGenerator.useManifestGeneratePaths).
+            # components/ is required: a policy's operator-install kustomization sets
+            # chartHome: ../../../../../components/, and dropping it fails the render outright.
+            # This also gates refresh, so a path a policy reads but that is not listed here means that
+            # policy silently stops picking up changes.
+            argocd.argoproj.io/manifest-generate-paths: '.;/components'
         # project + destination are required by the CRD on each generator template (they don't merge
         # from the top-level template for schema validation); the rest merges from spec.template below.
         spec:

--- a/autoshift/templates/autoshift-app-set.yaml
+++ b/autoshift/templates/autoshift-app-set.yaml
@@ -86,7 +86,7 @@ spec:
           name: '{{ .Release.Name }}-{{"{{"}} .path.basename {{"}}"}}'
           annotations:
             # Ship only this policy's own directory plus the shared charts it renders, instead of the
-            # whole repository, to the PolicyGenerator CMP sidecar. Honoured only when the repo-server
+            # whole repository, to the PolicyGenerator CMP sidecar. Honored only when the repo-server
             # runs with --plugin-use-manifest-generate-paths (gitops.policyGenerator.useManifestGeneratePaths).
             # components/ is required: a policy's operator-install kustomization sets
             # chartHome: ../../../../../components/, and dropping it fails the render outright.

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -530,7 +530,7 @@ hubClusterSets:
         # infra:
         #   rbac_policies:
         #     - 'g, my-admins, role:admin'
-        #   disableAdmin: 'true'
+        #   disableAdmin: true
         #   server:
         #     limits: { cpu: '500m', memory: '256Mi' }
         #     requests: { cpu: '125m', memory: '128Mi' }
@@ -538,13 +538,14 @@ hubClusterSets:
         #   repo:
         #     limits: { cpu: '1000m', memory: '1024Mi' }
         #     requests: { cpu: '250m', memory: '256Mi' }
+        #     replicas: 3
         #     cluster_ca_bundle: false
         #   controller:
         #     limits: { cpu: '2000m', memory: '2048Mi' }
         #     requests: { cpu: '250m', memory: '1024Mi' }
-        #     statusProcessors: '20'
-        #     operationProcessors: '10'
-        #   ha: { enabled: 'false' }
+        #     statusProcessors: 20
+        #     operationProcessors: 10
+        #   ha: { enabled: false }
         #   redis: {}
         #   dex: {}
         #   applicationSet: {}

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -538,11 +538,10 @@ hubClusterSets:
         # than appending to it, so carry the cluster-admin lines over unless you mean to drop them.
         # A `g` line takes a user or a group, but with OpenShift login the user identity is an
         # opaque Dex sub rather than a username, so name OpenShift Groups here.
-        # repo.replicas and the controller memory both default higher with the
-        # PolicyGenerator plugin (3 replicas and 6Gi) than without (1 replica, 2048Mi limit and
-        # 1024Mi request), and setting either here overrides both modes. The gitops-cluster-ca-bundle label overrides
-        # repo.cluster_ca_bundle. Raise the controller processors to 50 status and 25 operation for
-        # 1000 or more Applications. policyGenerator sizes the CMP sidecar that performs the render,
+        # repo.replicas defaults to 1; raise it for availability or a much larger policy set.
+        # Controller memory is 4Gi limit / 1Gi request, from a measured 843Mi peak.
+        # controller.statusProcessors is the main lever on how fast the fleet converges.
+        # The gitops-cluster-ca-bundle label overrides repo.cluster_ca_bundle. policyGenerator sizes the CMP sidecar that performs the render,
         # so raise it when manifest generation times out, and its tarExclusions trim the repository
         # tarball streamed to that sidecar. tarExclusions is repo-server WIDE, so keep it to .git;
         # per-Application scoping comes from useManifestGeneratePaths. All apply only where the
@@ -567,7 +566,7 @@ hubClusterSets:
         #       maxReplicas: 5
         #       targetCPUUtilizationPercentage: 50
         #   repo:
-        #     replicas: 3
+        #     replicas: 1
         #     cluster_ca_bundle: false
         #     limits:
         #       cpu: '2000m'
@@ -576,14 +575,14 @@ hubClusterSets:
         #       cpu: '500m'
         #       memory: '512Mi'
         #   controller:
-        #     statusProcessors: 20
-        #     operationProcessors: 10
+        #     statusProcessors: 50
+        #     operationProcessors: 25
         #     limits:
         #       cpu: '2000m'
-        #       memory: '6Gi'
+        #       memory: '4Gi'
         #     requests:
         #       cpu: '250m'
-        #       memory: '1024Mi'
+        #       memory: '1Gi'
         #   ha:
         #     enabled: false
         #     limits:

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -523,32 +523,100 @@ hubClusterSets:
         # infra-gitops instance). Drives gitops-disable-default-argocd (disable = not defaultInstance).
         # defaultInstance: false
         #
-        # Infra (main) ArgoCD instance config — same knobs as teams.<team> below, plus infra-only fields
-        # (server.autoscale, controller.statusProcessors/operationProcessors, repo.cluster_ca_bundle).
-        # The openshift-gitops policy reads these from this cluster's rendered-config at enforcement time
-        # (like the teams instances), so one policy serves per-cluster values; omit any field to keep default.
+        # Infra (main) ArgoCD instance config: the same knobs as teams.<team> below, plus the
+        # infra-only fields server.autoscale, controller.statusProcessors,
+        # controller.operationProcessors, repo.replicas and repo.cluster_ca_bundle. The
+        # openshift-gitops policy reads these from this cluster's rendered-config at enforcement
+        # time, so one policy serves per-cluster values.
+        #
+        # Every field is optional. Omit one and it falls back to the chart default in
+        # policies/stable/openshift-gitops/values.yaml, the same file the bootstrap chart reads, so
+        # bootstrap and day 2 agree. The block below is those defaults, so uncommenting it as is
+        # changes nothing.
+        #
+        # rbac_policies is the COMPLETE Argo CD RBAC policy and replaces the chart default rather
+        # than appending to it, so carry the cluster-admin lines over unless you mean to drop them.
+        # A `g` line takes a user or a group, but with OpenShift login the user identity is an
+        # opaque Dex sub rather than a username, so name OpenShift Groups here.
+        # repo.replicas and the controller memory both default higher with the
+        # PolicyGenerator plugin (3 replicas and 6Gi) than without (1 replica, 2048Mi limit and
+        # 1024Mi request), and setting either here overrides both modes. The gitops-cluster-ca-bundle label overrides
+        # repo.cluster_ca_bundle. Raise the controller processors to 50 status and 25 operation for
+        # 1000 or more Applications. policyGenerator sizes the CMP sidecar that performs the render,
+        # so raise it when manifest generation times out; it applies only where the plugin is on.
+        #
+        # Full table: docs/values-reference.md, "OpenShift GitOps".
         # infra:
         #   rbac_policies:
+        #     - 'g, system:cluster-admins, role:admin'
+        #     - 'g, cluster-admins, role:admin'
         #     - 'g, my-admins, role:admin'
-        #   disableAdmin: true
+        #   disableAdmin: false
         #   server:
-        #     limits: { cpu: '500m', memory: '256Mi' }
-        #     requests: { cpu: '125m', memory: '128Mi' }
-        #     autoscale: { enabled: false, maxReplicas: 3 }
+        #     limits:
+        #       cpu: '500m'
+        #       memory: '256Mi'
+        #     requests:
+        #       cpu: '125m'
+        #       memory: '128Mi'
+        #     autoscale:
+        #       enabled: true
+        #       maxReplicas: 5
+        #       targetCPUUtilizationPercentage: 50
         #   repo:
-        #     limits: { cpu: '1000m', memory: '1024Mi' }
-        #     requests: { cpu: '250m', memory: '256Mi' }
         #     replicas: 3
         #     cluster_ca_bundle: false
+        #     limits:
+        #       cpu: '2000m'
+        #       memory: '2048Mi'
+        #     requests:
+        #       cpu: '500m'
+        #       memory: '512Mi'
         #   controller:
-        #     limits: { cpu: '2000m', memory: '2048Mi' }
-        #     requests: { cpu: '250m', memory: '1024Mi' }
         #     statusProcessors: 20
         #     operationProcessors: 10
-        #   ha: { enabled: false }
-        #   redis: {}
-        #   dex: {}
-        #   applicationSet: {}
+        #     limits:
+        #       cpu: '2000m'
+        #       memory: '6Gi'
+        #     requests:
+        #       cpu: '250m'
+        #       memory: '1024Mi'
+        #   ha:
+        #     enabled: false
+        #     limits:
+        #       cpu: '500m'
+        #       memory: '256Mi'
+        #     requests:
+        #       cpu: '250m'
+        #       memory: '128Mi'
+        #   redis:
+        #     limits:
+        #       cpu: '500m'
+        #       memory: '256Mi'
+        #     requests:
+        #       cpu: '250m'
+        #       memory: '128Mi'
+        #   dex:
+        #     limits:
+        #       cpu: '500m'
+        #       memory: '256Mi'
+        #     requests:
+        #       cpu: '250m'
+        #       memory: '128Mi'
+        #   applicationSet:
+        #     limits:
+        #       cpu: '2'
+        #       memory: '1Gi'
+        #     requests:
+        #       cpu: '250m'
+        #       memory: '512Mi'
+        #   policyGenerator:
+        #     limits:
+        #       cpu: '2000m'
+        #       memory: '2048Mi'
+        #     requests:
+        #       cpu: '500m'
+        #       memory: '512Mi'
         teams:
           dev:
             gitops_rbac_policies:

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -543,7 +543,10 @@ hubClusterSets:
         # 1024Mi request), and setting either here overrides both modes. The gitops-cluster-ca-bundle label overrides
         # repo.cluster_ca_bundle. Raise the controller processors to 50 status and 25 operation for
         # 1000 or more Applications. policyGenerator sizes the CMP sidecar that performs the render,
-        # so raise it when manifest generation times out; it applies only where the plugin is on.
+        # so raise it when manifest generation times out, and its tarExclusions trim the repository
+        # tarball streamed to that sidecar. tarExclusions is repo-server WIDE, so keep it to .git;
+        # per-Application scoping comes from useManifestGeneratePaths. All apply only where the
+        # plugin is on.
         #
         # Full table: docs/values-reference.md, "OpenShift GitOps".
         # infra:
@@ -617,6 +620,9 @@ hubClusterSets:
         #     requests:
         #       cpu: '500m'
         #       memory: '512Mi'
+        #     tarExclusions:
+        #       - '.git/*'
+        #     useManifestGeneratePaths: true
         teams:
           dev:
             gitops_rbac_policies:

--- a/docs/gradual-rollout.md
+++ b/docs/gradual-rollout.md
@@ -5,6 +5,7 @@ This guide shows how to deploy multiple versions of AutoShift side-by-side for g
 ## Overview
 
 Deploy two AutoShift releases simultaneously using the `versionedClusterSets` feature:
+
 - `as-0-0-1` with `versionedClusterSets: true` automatically creates `hub-0-0-1` clusterset
 - `as-0-0-2` with `versionedClusterSets: true` automatically creates `hub-0-0-2` clusterset
 
@@ -15,12 +16,14 @@ Migrate clusters by moving them from one clusterset to another.
 When `versionedClusterSets: true`, the version/branch is automatically appended to all ClusterSet names:
 
 **OCI Mode** (uses `autoshiftOciVersion`):
+
 | Values Definition | `autoshiftOciVersion` | Resulting ClusterSet |
 |-------------------|---------------------|----------------------|
 | `hubClusterSets.hub` | `0.0.1` | `hub-0-0-1` |
 | `managedClusterSets.managed` | `0.0.2` | `managed-0-0-2` |
 
 **Git Mode** (uses `autoshiftGitBranchTag`):
+
 | Values Definition | `autoshiftGitBranchTag` | Resulting ClusterSet |
 |-------------------|----------------------|----------------------|
 | `hubClusterSets.hub` | `main` | `hub-main` |

--- a/docs/values-reference.md
+++ b/docs/values-reference.md
@@ -311,14 +311,14 @@ bootstrap and Day 2 agree. Set a field here to override it for one cluster or cl
 | `server.autoscale.enabled` | bool | `true` | Horizontal pod autoscaling for the server |
 | `server.autoscale.maxReplicas` | int | `5` | Upper bound for server autoscaling |
 | `server.autoscale.targetCPUUtilizationPercentage` | int | `50` | CPU target that triggers server autoscaling |
-| `repo.replicas` | int | `3` with the PolicyGenerator plugin, `1` without | Repo server replicas. The plugin render is heavy, so source mode spreads it across pods rather than thrashing a single repo server when the `ApplicationSet` fans out to every policy at once. Setting this overrides both modes |
+| `repo.replicas` | int | `1` | Repo server replicas. One is enough once `useManifestGeneratePaths` scopes each render to a single policy directory. Raise for availability or a much larger policy set |
 | `repo.limits` | map | cpu `2000m`, memory `2048Mi` | Repo server resource limits |
 | `repo.requests` | map | cpu `500m`, memory `512Mi` | Repo server resource requests |
 | `repo.cluster_ca_bundle` | bool | `false` | Inject the cluster trusted certificate authority bundle into the repo server. The `gitops-cluster-ca-bundle` label overrides this |
-| `controller.statusProcessors` | int | `20` | Concurrent status reconciliations. Consider 50 for 1000 or more Applications |
-| `controller.operationProcessors` | int | `10` | Concurrent sync operations. Consider 25 for 1000 or more Applications |
-| `controller.limits` | map | cpu `2000m`, memory `6Gi` with the PolicyGenerator plugin, `2048Mi` without | Application controller resource limits |
-| `controller.requests` | map | cpu `250m`, memory `6Gi` with the PolicyGenerator plugin, `1024Mi` without | Application controller resource requests. Source mode fans the `ApplicationSet` out to an Application per policy directory, which drives the controller far harder than consuming prerendered charts does |
+| `controller.statusProcessors` | int | `50` | Concurrent status reconciliations. AutoShift creates an Application per policy, so even a small hub carries dozens. This is the main lever on how fast the fleet converges |
+| `controller.operationProcessors` | int | `25` | Concurrent sync operations |
+| `controller.limits` | map | cpu `2000m`, memory `4Gi` | Application controller resource limits, sized for a full refresh storm |
+| `controller.requests` | map | cpu `250m`, memory `1Gi` | Application controller resource requests. Measured peak was 843Mi on a hub with 51 Applications and 194 Policies during a full refresh. Requests are deliberately below limits so the pod is Burstable and does not reserve the ceiling |
 | `ha.enabled` | bool | `false` | Run Argo CD in high availability mode |
 | `ha.limits` | map | cpu `500m`, memory `256Mi` | High availability resource limits |
 | `ha.requests` | map | cpu `250m`, memory `128Mi` | High availability resource requests |

--- a/docs/values-reference.md
+++ b/docs/values-reference.md
@@ -327,6 +327,8 @@ bootstrap and Day 2 agree. Set a field here to override it for one cluster or cl
 | `dex.limits` | map | cpu `500m`, memory `256Mi` | Dex resource limits |
 | `dex.requests` | map | cpu `250m`, memory `128Mi` | Dex resource requests |
 | `policyGenerator.limits` | map | cpu `2000m`, memory `2048Mi` | PolicyGenerator plugin sidecar resource limits. Present only when the plugin is enabled |
+| `policyGenerator.tarExclusions` | list | `.git/*` | Paths excluded from the repository tarball the repo server streams to a plugin sidecar. This setting is repo server wide, so it affects every plugin rendered Application on this Argo CD. Only `.git` is listed because no repository serves manifests from it. Adding generic names such as `docs/` risks silently emptying another team's Application |
+| `policyGenerator.useManifestGeneratePaths` | bool | `true` | Honour the `argocd.argoproj.io/manifest-generate-paths` annotation that the AutoShift `ApplicationSet` stamps on each generated policy Application, so a policy ships only its own directory and `components/`. The flag has no effect on Applications without the annotation |
 | `policyGenerator.requests` | map | cpu `500m`, memory `512Mi` | PolicyGenerator plugin sidecar resource requests. This container runs the render, so it is the one to raise when manifest generation times out |
 | `applicationSet.limits` | map | cpu `2`, memory `1Gi` | ApplicationSet controller resource limits |
 | `applicationSet.requests` | map | cpu `250m`, memory `512Mi` | ApplicationSet controller resource requests |

--- a/docs/values-reference.md
+++ b/docs/values-reference.md
@@ -244,8 +244,8 @@ is created on the hub above it. See
 | `valuesTargetRevision` | string | `main` | Branch or tag of the values repository |
 | `versionedClusterSets` | bool | `false` | Suffix clusterset names with the version tag |
 | `useRepoSecret` | bool | `false` | Copy a repository Secret into the hub's Argo CD namespace, for private repositories |
-| `repoSecretRef` | map | `{name: autoshift-repo-secret, namespace: <policy namespace>}` | Source Secret to copy |
-| `valuesRepoSecretRef` | map | `{name: autoshift-values-repo-secret, namespace: <policy namespace>}` | Source Secret for the values repository |
+| `repoSecretRef` | map | name `autoshift-repo-secret`, namespace `<policy namespace>` | Source Secret to copy |
+| `valuesRepoSecretRef` | map | name `autoshift-values-repo-secret`, namespace `<policy namespace>` | Source Secret for the values repository |
 
 An entry that names a reserved or over-long `appName`, or that sets `ociRepo` without `ociVersion`,
 creates nothing rather than a broken Application.
@@ -285,6 +285,64 @@ Manages the OpenShift GitOps operator installation and systems ArgoCD instance. 
 | `gitops-cluster-ca-bundle`      | bool      | `false`                   | Inject cluster trusted CA bundle into ArgoCD repo server |
 | `gitops-namespace`              | string    | (`gitopsNamespace`)       | Per-cluster override of the ArgoCD namespace, e.g. in hub-of-hubs setups |
 | `gitops-disable-default-argocd` | bool      | `true`                    | Controls `DISABLE_DEFAULT_ARGOCD_INSTANCE` on the operator Subscription |
+
+**Config block** (`config.gitops`):
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `namespace` | string | (`gitopsNamespace`) | Argo CD namespace for the whole deployment. Overrides `gitopsNamespace` |
+| `defaultInstance` | bool | `false` | Keep the operator default Argo CD instance in `openshift-gitops`. Drives `gitops-disable-default-argocd` |
+| `policyGenerator` | bool | (deployment flag) | Install the PolicyGenerator plugin sidecar in the infra repo server. Git and source hubs must set `true`. Read only from the self-managed hub cluster set |
+| `teams` | map | | Developer Argo CD instances, one entry per team. See [Developer OpenShift gitops](#developer-openshift-gitops) |
+| `infra` | map | | Tuning for the infra Argo CD instance. See the table below |
+
+**Config block** (`config.gitops.infra`):
+
+Every field is optional. A field left unset falls back to the chart default in
+`policies/stable/openshift-gitops/values.yaml`, which is the same file the bootstrap chart reads, so
+bootstrap and Day 2 agree. Set a field here to override it for one cluster or cluster set.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rbac_policies` | list | admin for `system:cluster-admins`, `cluster-admins` and `openshift-systems` | The complete Argo CD RBAC policy. Setting it replaces the default list rather than appending. A `g` line assigns a subject to a role and accepts a user or a group, but OpenShift login identifies users by an opaque Dex `sub` claim rather than a username, so name OpenShift Groups here. `defaultPolicy` is empty, so an empty list leaves no access apart from the built-in admin account |
+| `disableAdmin` | bool | `false` | Disable the Argo CD built-in admin account |
+| `server.limits` | map | cpu `500m`, memory `256Mi` | Argo CD server resource limits |
+| `server.requests` | map | cpu `125m`, memory `128Mi` | Argo CD server resource requests |
+| `server.autoscale.enabled` | bool | `true` | Horizontal pod autoscaling for the server |
+| `server.autoscale.maxReplicas` | int | `5` | Upper bound for server autoscaling |
+| `server.autoscale.targetCPUUtilizationPercentage` | int | `50` | CPU target that triggers server autoscaling |
+| `repo.replicas` | int | `3` with the PolicyGenerator plugin, `1` without | Repo server replicas. The plugin render is heavy, so source mode spreads it across pods rather than thrashing a single repo server when the `ApplicationSet` fans out to every policy at once. Setting this overrides both modes |
+| `repo.limits` | map | cpu `2000m`, memory `2048Mi` | Repo server resource limits |
+| `repo.requests` | map | cpu `500m`, memory `512Mi` | Repo server resource requests |
+| `repo.cluster_ca_bundle` | bool | `false` | Inject the cluster trusted certificate authority bundle into the repo server. The `gitops-cluster-ca-bundle` label overrides this |
+| `controller.statusProcessors` | int | `20` | Concurrent status reconciliations. Consider 50 for 1000 or more Applications |
+| `controller.operationProcessors` | int | `10` | Concurrent sync operations. Consider 25 for 1000 or more Applications |
+| `controller.limits` | map | cpu `2000m`, memory `6Gi` with the PolicyGenerator plugin, `2048Mi` without | Application controller resource limits |
+| `controller.requests` | map | cpu `250m`, memory `6Gi` with the PolicyGenerator plugin, `1024Mi` without | Application controller resource requests. Source mode fans the `ApplicationSet` out to an Application per policy directory, which drives the controller far harder than consuming prerendered charts does |
+| `ha.enabled` | bool | `false` | Run Argo CD in high availability mode |
+| `ha.limits` | map | cpu `500m`, memory `256Mi` | High availability resource limits |
+| `ha.requests` | map | cpu `250m`, memory `128Mi` | High availability resource requests |
+| `redis.limits` | map | cpu `500m`, memory `256Mi` | Redis resource limits |
+| `redis.requests` | map | cpu `250m`, memory `128Mi` | Redis resource requests |
+| `dex.limits` | map | cpu `500m`, memory `256Mi` | Dex resource limits |
+| `dex.requests` | map | cpu `250m`, memory `128Mi` | Dex resource requests |
+| `policyGenerator.limits` | map | cpu `2000m`, memory `2048Mi` | PolicyGenerator plugin sidecar resource limits. Present only when the plugin is enabled |
+| `policyGenerator.requests` | map | cpu `500m`, memory `512Mi` | PolicyGenerator plugin sidecar resource requests. This container runs the render, so it is the one to raise when manifest generation times out |
+| `applicationSet.limits` | map | cpu `2`, memory `1Gi` | ApplicationSet controller resource limits |
+| `applicationSet.requests` | map | cpu `250m`, memory `512Mi` | ApplicationSet controller resource requests |
+
+```yaml
+clusterSets:
+  hub:
+    config:
+      gitops:
+        infra:
+          controller:
+            statusProcessors: 50
+            operationProcessors: 25
+          repo:
+            replicas: 5
+```
 
 #### Using a custom ArgoCD namespace
 

--- a/openshift-gitops/templates/argo-cd.yaml
+++ b/openshift-gitops/templates/argo-cd.yaml
@@ -52,11 +52,7 @@ spec:
     {{- /* Install the policy-generator CMP sidecar only when enabled (git/source bootstrap); OCI-only
            bootstrap sets false. Default true for backwards compatibility. */}}
     {{- $pgEnabled := ternary ($pg.enabled) true (hasKey $pg "enabled") }}
-    {{- /* With the CMP the render (kustomize --enable-helm + PolicyGenerator + nested Helm) is
-           CPU and memory heavy, so spread it across pods instead of thrashing a single repo-server
-           when the ApplicationSet fans out to all policies/* at once. Without it the repo-server
-           only pulls prerendered Helm charts, so one pod is enough. */}}
-    replicas: {{ ternary ((($pg.repo).replicas) | default 3) (((.Values.gitops.repo).replicas) | default 1) $pgEnabled }}
+    replicas: {{ ((.Values.gitops.repo).replicas) | default 1 }}
     {{- if $pgEnabled }}
     extraRepoCommandArgs:
       {{- range ($pg.tarExclusions | default list) }}
@@ -208,12 +204,12 @@ spec:
   controller:
     resources:
       limits:
-        cpu: {{ ternary (((($pg.controller).limits).cpu) | default "2000m") (((.Values.gitops.controller).limits).cpu | default "2000m") $pgEnabled }}
+        cpu: {{ ((.Values.gitops.controller).limits).cpu | default "2000m" }}
         # 4Gi: the controller OOMKills at 2Gi once the ApplicationSet has fanned out to all policies/*.
-        memory: {{ ternary (((($pg.controller).limits).memory) | default "4096Mi") (((.Values.gitops.controller).limits).memory | default "4096Mi") $pgEnabled }}
+        memory: {{ ((.Values.gitops.controller).limits).memory | default "4096Mi" }}
       requests:
-        cpu: {{ ternary (((($pg.controller).requests).cpu) | default "250m") (((.Values.gitops.controller).requests).cpu | default "250m") $pgEnabled }}
-        memory: {{ ternary (((($pg.controller).requests).memory) | default "1024Mi") (((.Values.gitops.controller).requests).memory | default "1024Mi") $pgEnabled }}
+        cpu: {{ ((.Values.gitops.controller).requests).cpu | default "250m" }}
+        memory: {{ ((.Values.gitops.controller).requests).memory | default "1024Mi" }}
   applicationSet:
     resources:
       limits:

--- a/openshift-gitops/templates/argo-cd.yaml
+++ b/openshift-gitops/templates/argo-cd.yaml
@@ -39,25 +39,24 @@ spec:
     provider: dex
   rbac:
     defaultPolicy: ''
-    # All cluster admins get Argo CD admin: system:cluster-admins is the built-in kubeadmin group;
-    # cluster-admins is the OpenShift group users are added to for cluster-admin. Grant both.
+    # Every line comes from gitops.rbac_policies. Nothing is granted implicitly: defaultPolicy is
+    # empty, so an empty list means no access apart from the built-in admin account.
     policy: |
-      g, system:cluster-admins, role:admin
-      g, cluster-admins, role:admin
-    {{- range .Values.gitops.rbac_policies}}
+    {{- range .Values.gitops.rbac_policies }}
       {{ . }}
     {{- end }}
     scopes: '[groups]'
   repo:
-    # Multiple repo-server replicas so PolicyGenerator CMP renders (kustomize --enable-helm + PG +
-    # nested Helm — CPU/memory heavy) spread across pods instead of thrashing a single one when the
-    # ApplicationSet fans out to all policies/* at once.
-    replicas: {{ ((.Values.gitops.repo).replicas) | default 3 }}
     {{- $caBundle := .Values.gitops.repo.cluster_ca_bundle }}
     {{- $pg := (.Values.gitops.policyGenerator | default dict) }}
     {{- /* Install the policy-generator CMP sidecar only when enabled (git/source bootstrap); OCI-only
            bootstrap sets false. Default true for backwards compatibility. */}}
     {{- $pgEnabled := ternary ($pg.enabled) true (hasKey $pg "enabled") }}
+    {{- /* With the CMP the render (kustomize --enable-helm + PolicyGenerator + nested Helm) is
+           CPU and memory heavy, so spread it across pods instead of thrashing a single repo-server
+           when the ApplicationSet fans out to all policies/* at once. Without it the repo-server
+           only pulls prerendered Helm charts, so one pod is enough. */}}
+    replicas: {{ ternary ((($pg.repo).replicas) | default 3) (((.Values.gitops.repo).replicas) | default 1) $pgEnabled }}
     {{- /* Declared at repo scope so they're visible in the initContainers/sidecar blocks below. */}}
     {{- $acmImage := ($pg).subscriptionImage }}
     {{- $argoImage := ($pg).sidecarImage }}
@@ -166,11 +165,11 @@ spec:
         # Without resources it competes unbounded and renders time out under fan-out load.
         resources:
           limits:
-            cpu: {{ (((.Values.gitops.policyGenerator).resources).limits).cpu | default "2000m" }}
-            memory: {{ (((.Values.gitops.policyGenerator).resources).limits).memory | default "2048Mi" }}
+            cpu: {{ ((.Values.gitops.policyGenerator).limits).cpu | default "2000m" }}
+            memory: {{ ((.Values.gitops.policyGenerator).limits).memory | default "2048Mi" }}
           requests:
-            cpu: {{ (((.Values.gitops.policyGenerator).resources).requests).cpu | default "500m" }}
-            memory: {{ (((.Values.gitops.policyGenerator).resources).requests).memory | default "512Mi" }}
+            cpu: {{ ((.Values.gitops.policyGenerator).requests).cpu | default "500m" }}
+            memory: {{ ((.Values.gitops.policyGenerator).requests).memory | default "512Mi" }}
     {{- end }}
     resources:
       limits:
@@ -199,12 +198,12 @@ spec:
   controller:
     resources:
       limits:
-        cpu: {{ ((.Values.gitops.controller).limits).cpu | default "2000m" }}
+        cpu: {{ ternary (((($pg.controller).limits).cpu) | default "2000m") (((.Values.gitops.controller).limits).cpu | default "2000m") $pgEnabled }}
         # 4Gi: the controller OOMKills at 2Gi once the ApplicationSet has fanned out to all policies/*.
-        memory: {{ ((.Values.gitops.controller).limits).memory | default "4096Mi" }}
+        memory: {{ ternary (((($pg.controller).limits).memory) | default "4096Mi") (((.Values.gitops.controller).limits).memory | default "4096Mi") $pgEnabled }}
       requests:
-        cpu: {{ ((.Values.gitops.controller).requests).cpu | default "250m" }}
-        memory: {{ ((.Values.gitops.controller).requests).memory | default "1024Mi" }}
+        cpu: {{ ternary (((($pg.controller).requests).cpu) | default "250m") (((.Values.gitops.controller).requests).cpu | default "250m") $pgEnabled }}
+        memory: {{ ternary (((($pg.controller).requests).memory) | default "1024Mi") (((.Values.gitops.controller).requests).memory | default "1024Mi") $pgEnabled }}
   applicationSet:
     resources:
       limits:

--- a/openshift-gitops/templates/argo-cd.yaml
+++ b/openshift-gitops/templates/argo-cd.yaml
@@ -57,6 +57,16 @@ spec:
            when the ApplicationSet fans out to all policies/* at once. Without it the repo-server
            only pulls prerendered Helm charts, so one pod is enough. */}}
     replicas: {{ ternary ((($pg.repo).replicas) | default 3) (((.Values.gitops.repo).replicas) | default 1) $pgEnabled }}
+    {{- if $pgEnabled }}
+    extraRepoCommandArgs:
+      {{- range ($pg.tarExclusions | default list) }}
+      - --plugin-tar-exclude
+      - {{ . | quote }}
+      {{- end }}
+      {{- if $pg.useManifestGeneratePaths }}
+      - --plugin-use-manifest-generate-paths
+      {{- end }}
+    {{- end }}
     {{- /* Declared at repo scope so they're visible in the initContainers/sidecar blocks below. */}}
     {{- $acmImage := ($pg).subscriptionImage }}
     {{- $argoImage := ($pg).sidecarImage }}

--- a/openshift-gitops/values.yaml
+++ b/openshift-gitops/values.yaml
@@ -43,9 +43,46 @@ gitops:
     # mode (renders PolicyGenerator dirs live); disabled for OCI-only deployments (prerendered Helm).
     # The ApplicationSet forwards the effective value from the deployment's policyGenerator flag.
     enabled: true
+    repo:
+      # PolicyGenerator rendering (kustomize --enable-helm plus a nested Helm render) is heavy, so
+      # spread it across pods instead of thrashing a single repo-server when the ApplicationSet
+      # fans out to every policies/* at once.
+      replicas: 3
+    controller:
+      # Source mode fans the ApplicationSet out to an Application per policies/* directory, which
+      # drives the application controller far harder than consuming prerendered charts does. The
+      # controller OOMKills below this.
+      limits:
+        cpu: 2000m
+        memory: 6Gi
+      requests:
+        cpu: 250m
+        memory: 6Gi
+    # The CMP sidecar's own container resources. It runs the actual kustomize/PolicyGenerator/Helm
+    # render, so it needs real CPU; without resources it competes unbounded and renders time out
+    # under fan-out load. Override per cluster with config.gitops.infra.policyGenerator.
+    limits:
+      cpu: 2000m
+      memory: 2048Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi
   # Dev team cluster-scoped namespaces are auto-discovered from managed cluster labels
   # matching autoshift.io/gitops-dev-team-<team>-cluster-scoped: 'true'
+  # Argo CD RBAC. A `g` line assigns a subject to a role; the subject may be a user or a group. What
+  # makes groups the practical unit is the identity: scopes is '[groups]', checked alongside the
+  # always-matched sub claim, and with OpenShift login sub is an opaque Dex identifier rather than a
+  # username. Naming a user means pasting that opaque value.
+  #   system:cluster-admins - carried by kubeadmin (kube:admin)
+  #   cluster-admins        - the group Red Hat's OpenShift login procedure creates:
+  #                           oc adm groups new cluster-admins
+  # defaultPolicy is empty, so this list is the only access apart from the built-in admin account.
+  # Overridable per cluster with config.gitops.infra.rbac_policies, which REPLACES this list rather
+  # than appending to it. Avoid names containing commas (an LDAP group DN) - the comma is the field
+  # separator and the line is rejected as an invalid RBAC policy.
   rbac_policies:
+    - 'g, system:cluster-admins, role:admin'
+    - 'g, cluster-admins, role:admin'
     - 'g, openshift-systems, role:admin'
   # OPTIONAL
   controller:
@@ -55,10 +92,10 @@ gitops:
     operationProcessors: 10 # concurrent sync operations (default: 10)
     limits:
       cpu: 2000m
-      memory: 6Gi
+      memory: 2048Mi
     requests:
       cpu: 250m
-      memory: 6Gi
+      memory: 1024Mi
   ha:
     enabled: false
     limits:
@@ -79,9 +116,9 @@ gitops:
     # enabling the cluster_ca_bundle will inject the cluster's trusted CA bundle into the repo
     # server that Argo CD uses. This allows Argo CD to connect to repositories using custom certificates.
     cluster_ca_bundle: false
-    # Multiple replicas so PolicyGenerator CMP renders spread across pods when the ApplicationSet
-    # fans out to every policies/* at once (a single repo-server thrashes and renders time out).
-    replicas: 3
+    # Repo-server replicas WITHOUT the PolicyGenerator CMP: the repo-server only pulls prerendered
+    # Helm charts, so one pod is enough. The heavier source-mode count is policyGenerator.repo.replicas.
+    replicas: 1
     limits:
       cpu: 2000m
       memory: 2048Mi

--- a/openshift-gitops/values.yaml
+++ b/openshift-gitops/values.yaml
@@ -43,21 +43,6 @@ gitops:
     # mode (renders PolicyGenerator dirs live); disabled for OCI-only deployments (prerendered Helm).
     # The ApplicationSet forwards the effective value from the deployment's policyGenerator flag.
     enabled: true
-    repo:
-      # PolicyGenerator rendering (kustomize --enable-helm plus a nested Helm render) is heavy, so
-      # spread it across pods instead of thrashing a single repo-server when the ApplicationSet
-      # fans out to every policies/* at once.
-      replicas: 3
-    controller:
-      # Source mode fans the ApplicationSet out to an Application per policies/* directory, which
-      # drives the application controller far harder than consuming prerendered charts does. The
-      # controller OOMKills below this.
-      limits:
-        cpu: 2000m
-        memory: 6Gi
-      requests:
-        cpu: 250m
-        memory: 6Gi
     # Excluded from the repository tarball the repo-server streams to a CMP sidecar. This setting is
     # repo-server WIDE, so it hits every plugin-rendered Application on this Argo CD, not just
     # AutoShift's. Only .git is listed because no repository serves manifests out of it; do not add
@@ -82,8 +67,6 @@ gitops:
     requests:
       cpu: 500m
       memory: 512Mi
-  # Dev team cluster-scoped namespaces are auto-discovered from managed cluster labels
-  # matching autoshift.io/gitops-dev-team-<team>-cluster-scoped: 'true'
   # Argo CD RBAC. A `g` line assigns a subject to a role; the subject may be a user or a group. What
   # makes groups the practical unit is the identity: scopes is '[groups]', checked alongside the
   # always-matched sub claim, and with OpenShift login sub is an opaque Dex identifier rather than a
@@ -103,14 +86,22 @@ gitops:
   controller:
     # Scaling: increase processors for environments with many Applications
     # Recommended: 50 status / 25 operation for 1000+ Applications
-    statusProcessors: 20 # concurrent status reconciliations (default: 20)
-    operationProcessors: 10 # concurrent sync operations (default: 10)
+    # AutoShift generates an Application per policy directory, so even a minimal hub carries dozens.
+    # Measured on a 51-Application hub: a full refresh took 141s at 50/25 against 225s at the Argo CD
+    # defaults of 20/10, for 640Mi of controller memory. Raise further for a much larger policy set.
+    statusProcessors: 50 # concurrent status reconciliations (Argo CD default: 20)
+    operationProcessors: 25 # concurrent sync operations (Argo CD default: 10)
+    # Measured peak 843Mi on a hub with 51 Applications and 194 Policies at 50 processors, during a
+    # full hard-refresh storm. Requests sized for steady state and limits for that storm with room to
+    # spare; deliberately NOT equal, so the pod is Burstable and does not reserve the ceiling. A hub
+    # running several AutoShift deployments multiplies the per-Application share but not the cluster
+    # cache, which is the larger half. Re-measure before lowering rather than assuming.
     limits:
       cpu: 2000m
-      memory: 2048Mi
+      memory: 4Gi
     requests:
       cpu: 250m
-      memory: 1024Mi
+      memory: 1Gi
   ha:
     enabled: false
     limits:
@@ -131,8 +122,11 @@ gitops:
     # enabling the cluster_ca_bundle will inject the cluster's trusted CA bundle into the repo
     # server that Argo CD uses. This allows Argo CD to connect to repositories using custom certificates.
     cluster_ca_bundle: false
-    # Repo-server replicas WITHOUT the PolicyGenerator CMP: the repo-server only pulls prerendered
-    # Helm charts, so one pod is enough. The heavier source-mode count is policyGenerator.repo.replicas.
+    # Repo-server replicas. One is enough: with useManifestGeneratePaths each render ships only a
+    # policy's own directory, and a measured 51-Application refresh took 199s on one replica against
+    # 225s on three, with the repo-server idle at 14m CPU either way. The bottleneck is the
+    # application controller, not this. Raise it for availability or a much larger policy set, here
+    # or per cluster with config.gitops.infra.repo.replicas.
     replicas: 1
     limits:
       cpu: 2000m

--- a/openshift-gitops/values.yaml
+++ b/openshift-gitops/values.yaml
@@ -58,6 +58,21 @@ gitops:
       requests:
         cpu: 250m
         memory: 6Gi
+    # Excluded from the repository tarball the repo-server streams to a CMP sidecar. This setting is
+    # repo-server WIDE, so it hits every plugin-rendered Application on this Argo CD, not just
+    # AutoShift's. Only .git is listed because no repository serves manifests out of it; do not add
+    # generic names like docs/ or scripts/ unless this Argo CD serves AutoShift alone, or another
+    # team's plugin app that keeps manifests there will silently render empty. AutoShift scopes its
+    # own tarball per Application with useManifestGeneratePaths below instead.
+    # Go filepath.Match syntax, one --plugin-tar-exclude repo-server arg per entry.
+    tarExclusions:
+      - '.git/*'
+    # Honour the argocd.argoproj.io/manifest-generate-paths annotation, which the AutoShift
+    # ApplicationSet stamps on every generated policy Application so each one ships only its own
+    # directory plus components/ rather than the whole repository. Verified on a live hub: the flag
+    # is inert for Applications that do not carry the annotation, so other workloads on this Argo CD
+    # are unaffected.
+    useManifestGeneratePaths: true
     # The CMP sidecar's own container resources. It runs the actual kustomize/PolicyGenerator/Helm
     # render, so it needs real CPU; without resources it competes unbounded and renders time out
     # under fan-out load. Override per cluster with config.gitops.infra.policyGenerator.

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -184,11 +184,7 @@ spec:
                     policy: {{ "{{hub" }} $rbac | toJson {{ "hub}}" }}
                     scopes: '[groups]'
                   repo:
-                    # With the CMP the render is heavy, so spread it across pods; a single
-                    # repo-server thrashes and renders time out when the ApplicationSet fans out to
-                    # every policies/* at once. Without it the repo-server only pulls prerendered
-                    # Helm charts, so one pod is enough.
-                    replicas: {{ "{{hub" }} index $repo "replicas" | default (ternary {{ $.Values.gitops.policyGenerator.repo.replicas }} {{ $.Values.gitops.repo.replicas }} $pgEnabled) {{ "hub}}" }}
+                    replicas: {{ "{{hub" }} index $repo "replicas" | default {{ $.Values.gitops.repo.replicas }} {{ "hub}}" }}
                     {{ "{{hub-" }} if $pgEnabled {{ "hub}}" }}
                     # Trim the tarball streamed to the CMP sidecar on every render.
                     extraRepoCommandArgs:
@@ -311,18 +307,16 @@ spec:
                         cpu: {{ "{{hub" }} index $redisRequests "cpu" | default "{{ $.Values.gitops.redis.requests.cpu }}" {{ "hub}}" }}
                         memory: {{ "{{hub" }} index $redisRequests "memory" | default "{{ $.Values.gitops.redis.requests.memory }}" {{ "hub}}" }}
                   controller:
-                    # Source mode drives the controller far harder than consuming prerendered
-                    # charts does, so the sizing follows the PolicyGenerator gate like repo.replicas.
                     processors:
                       status: {{ "{{hub" }} index $controller "statusProcessors" | default {{ $.Values.gitops.controller.statusProcessors }} {{ "hub}}" }}
                       operation: {{ "{{hub" }} index $controller "operationProcessors" | default {{ $.Values.gitops.controller.operationProcessors }} {{ "hub}}" }}
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.limits.cpu }}" "{{ $.Values.gitops.controller.limits.cpu }}" $pgEnabled) {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.limits.memory }}" "{{ $.Values.gitops.controller.limits.memory }}" $pgEnabled) {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default "{{ $.Values.gitops.controller.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default "{{ $.Values.gitops.controller.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.requests.cpu }}" "{{ $.Values.gitops.controller.requests.cpu }}" $pgEnabled) {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerRequests "memory" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.requests.memory }}" "{{ $.Values.gitops.controller.requests.memory }}" $pgEnabled) {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default "{{ $.Values.gitops.controller.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerRequests "memory" | default "{{ $.Values.gitops.controller.requests.memory }}" {{ "hub}}" }}
                   applicationSet:
                     resources:
                       limits:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -101,10 +101,13 @@ spec:
             {{ "{{hub-" }} $controller := (index $infra "controller" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $controllerLimits := (index $controller "limits" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $controllerRequests := (index $controller "requests" | default dict) {{ "hub}}" }}
+            {{ "{{hub-" }} $pgSidecar := (index $infra "policyGenerator" | default dict) {{ "hub}}" }}
+            {{ "{{hub-" }} $pgSidecarLimits := (index $pgSidecar "limits" | default dict) {{ "hub}}" }}
+            {{ "{{hub-" }} $pgSidecarRequests := (index $pgSidecar "requests" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSet := (index $infra "applicationSet" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSetLimits := (index $applicationSet "limits" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSetRequests := (index $applicationSet "requests" | default dict) {{ "hub}}" }}
-            {{ "{{hub-" }} $rbac := "g, cluster-admins, role:admin\ng, system:cluster-admins, role:admin\n" {{ "hub}}" }}
+            {{ "{{hub-" }} $rbac := "" {{ "hub}}" }}
             {{ "{{hub-" }} range (index $infra "rbac_policies" | default (list{{ range $.Values.gitops.rbac_policies }} {{ . | quote }}{{ end }})) {{ "hub}}" }}
             {{ "{{hub-" }} $rbac = printf "%s%s\n" $rbac . {{ "hub}}" }}
             {{ "{{hub-" }} end {{ "hub}}" }}
@@ -172,15 +175,19 @@ spec:
                     provider: dex
                   rbac:
                     defaultPolicy: ''
-                    # cluster-admins + system:cluster-admins get Argo CD admin, plus any entries from
-                    # config.gitops.infra.rbac_policies ($rbac built at the top of this block).
+                    # Every line comes from config.gitops.infra.rbac_policies, falling back to this
+                    # chart's gitops.rbac_policies ($rbac built at the top of this block). Nothing is
+                    # granted implicitly: defaultPolicy is empty, so an empty list means no access
+                    # apart from the built-in admin account. A `g` line takes a user or a group,
+                    # but OpenShift login yields an opaque sub, so groups are the practical unit.
                     policy: {{ "{{hub" }} $rbac | toJson {{ "hub}}" }}
                     scopes: '[groups]'
                   repo:
-                    # Multiple replicas so PolicyGenerator CMP renders spread across pods when the
-                    # ApplicationSet fans out to every policies/* at once (a single repo-server
-                    # thrashes and renders time out).
-                    replicas: {{ "{{hub" }} index $repo "replicas" | default {{ $.Values.gitops.repo.replicas }} {{ "hub}}" }}
+                    # With the CMP the render is heavy, so spread it across pods; a single
+                    # repo-server thrashes and renders time out when the ApplicationSet fans out to
+                    # every policies/* at once. Without it the repo-server only pulls prerendered
+                    # Helm charts, so one pod is enough.
+                    replicas: {{ "{{hub" }} index $repo "replicas" | default (ternary {{ $.Values.gitops.policyGenerator.repo.replicas }} {{ $.Values.gitops.repo.replicas }} $pgEnabled) {{ "hub}}" }}
                     resources:
                       limits:
                         cpu: {{ "{{hub" }} index $repoLimits "cpu" | default "{{ $.Values.gitops.repo.limits.cpu }}" {{ "hub}}" }}
@@ -227,6 +234,15 @@ spec:
                         env:
                           - name: KUSTOMIZE_PLUGIN_HOME
                             value: /etc/kustomize/plugin
+                        # The sidecar runs the actual kustomize/PolicyGenerator/Helm render, so it
+                        # needs real CPU. Without resources it competes unbounded and renders time out.
+                        resources:
+                          limits:
+                            cpu: {{ "{{hub" }} index $pgSidecarLimits "cpu" | default "{{ $.Values.gitops.policyGenerator.limits.cpu }}" {{ "hub}}" }}
+                            memory: {{ "{{hub" }} index $pgSidecarLimits "memory" | default "{{ $.Values.gitops.policyGenerator.limits.memory }}" {{ "hub}}" }}
+                          requests:
+                            cpu: {{ "{{hub" }} index $pgSidecarRequests "cpu" | default "{{ $.Values.gitops.policyGenerator.requests.cpu }}" {{ "hub}}" }}
+                            memory: {{ "{{hub" }} index $pgSidecarRequests "memory" | default "{{ $.Values.gitops.policyGenerator.requests.memory }}" {{ "hub}}" }}
                         volumeMounts:
                           - name: var-files
                             mountPath: /var/run/argocd
@@ -283,16 +299,18 @@ spec:
                         cpu: {{ "{{hub" }} index $redisRequests "cpu" | default "{{ $.Values.gitops.redis.requests.cpu }}" {{ "hub}}" }}
                         memory: {{ "{{hub" }} index $redisRequests "memory" | default "{{ $.Values.gitops.redis.requests.memory }}" {{ "hub}}" }}
                   controller:
+                    # Source mode drives the controller far harder than consuming prerendered
+                    # charts does, so the sizing follows the PolicyGenerator gate like repo.replicas.
                     processors:
                       status: {{ "{{hub" }} index $controller "statusProcessors" | default {{ $.Values.gitops.controller.statusProcessors }} {{ "hub}}" }}
                       operation: {{ "{{hub" }} index $controller "operationProcessors" | default {{ $.Values.gitops.controller.operationProcessors }} {{ "hub}}" }}
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default "{{ $.Values.gitops.controller.limits.cpu }}" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default "{{ $.Values.gitops.controller.limits.memory }}" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.limits.cpu }}" "{{ $.Values.gitops.controller.limits.cpu }}" $pgEnabled) {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.limits.memory }}" "{{ $.Values.gitops.controller.limits.memory }}" $pgEnabled) {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default "{{ $.Values.gitops.controller.requests.cpu }}" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerRequests "memory" | default "{{ $.Values.gitops.controller.requests.memory }}" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.requests.cpu }}" "{{ $.Values.gitops.controller.requests.cpu }}" $pgEnabled) {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerRequests "memory" | default (ternary "{{ $.Values.gitops.policyGenerator.controller.requests.memory }}" "{{ $.Values.gitops.controller.requests.memory }}" $pgEnabled) {{ "hub}}" }}
                   applicationSet:
                     resources:
                       limits:

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -75,7 +75,9 @@ spec:
             {{ "{{hub" }} $gitopsNamespace := index .ManagedClusterLabels "autoshift.io/gitops-namespace" | default "{{ .Values.gitopsNamespace | default .Values.gitops.argoNamespace }}" {{ "hub}}" }}
             {{/* Infra ArgoCD tuning (resources, autoscale, processors, rbac) comes from this cluster's
                  rendered-config ConfigMap (config.gitops.infra), so one policy serves per-cluster values.
-                 Defaults below preserve the previous behavior when a field is unset. */}}
+                 When a field is unset there, the default is this chart's values.yaml, rendered in at Helm
+                 time, so bootstrap and day 2 read the same numbers. No inline literals: every key the
+                 templates below reference must exist in values.yaml or the render fails. */}}
             {{ "{{hub-" }} $rcm := (lookup "v1" "ConfigMap" .PolicyMetadata.namespace (printf "%s.rendered-config" .ManagedClusterName)) | default dict {{ "hub}}" }}
             {{ "{{hub-" }} $cfg := (index ($rcm.data | default dict) "config" | default "" | fromYaml | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $infra := (index (index $cfg "gitops" | default dict) "infra" | default dict) {{ "hub}}" }}
@@ -103,7 +105,7 @@ spec:
             {{ "{{hub-" }} $applicationSetLimits := (index $applicationSet "limits" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSetRequests := (index $applicationSet "requests" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $rbac := "g, cluster-admins, role:admin\ng, system:cluster-admins, role:admin\n" {{ "hub}}" }}
-            {{ "{{hub-" }} range (index $infra "rbac_policies" | default list) {{ "hub}}" }}
+            {{ "{{hub-" }} range (index $infra "rbac_policies" | default (list{{ range $.Values.gitops.rbac_policies }} {{ . | quote }}{{ end }})) {{ "hub}}" }}
             {{ "{{hub-" }} $rbac = printf "%s%s\n" $rbac . {{ "hub}}" }}
             {{ "{{hub-" }} end {{ "hub}}" }}
             {{/* The CMP sidecar image is the SAME image as the running argocd-repo-server (operator-set),
@@ -130,26 +132,26 @@ spec:
                   name: {{ .Values.gitops.argoName }}
                   namespace: {{ "{{hub" }} $gitopsNamespace {{ "hub}}" }}
                 spec:
-                  disableAdmin: {{ "{{hub" }} index $infra "disableAdmin" | default false {{ "hub}}" }}
+                  disableAdmin: {{ "{{hub" }} ternary (index $infra "disableAdmin") {{ $.Values.gitops.disableAdmin }} (hasKey $infra "disableAdmin") {{ "hub}}" }}
                   server:
-                    {{ "{{hub-" }} if (index $serverAutoscale "enabled" | default false) {{ "hub}}" }}
+                    {{ "{{hub-" }} if (ternary (index $serverAutoscale "enabled") {{ $.Values.gitops.server.autoscale.enabled }} (hasKey $serverAutoscale "enabled")) {{ "hub}}" }}
                     autoscale:
                       enabled: true
                       hpa:
-                        maxReplicas: {{ "{{hub" }} index $serverAutoscale "maxReplicas" | default 10 {{ "hub}}" }}
+                        maxReplicas: {{ "{{hub" }} index $serverAutoscale "maxReplicas" | default {{ $.Values.gitops.server.autoscale.maxReplicas }} {{ "hub}}" }}
                         scaleTargetRef:
                           apiVersion: "apps/v1"
                           kind: deployment
                           name: {{ $.Values.gitops.argoName }}-server
-                        targetCPUUtilizationPercentage: {{ "{{hub" }} index $serverAutoscale "targetCPUUtilizationPercentage" | default 50 {{ "hub}}" }}
+                        targetCPUUtilizationPercentage: {{ "{{hub" }} index $serverAutoscale "targetCPUUtilizationPercentage" | default {{ $.Values.gitops.server.autoscale.targetCPUUtilizationPercentage }} {{ "hub}}" }}
                     {{ "{{hub-" }} end {{ "hub}}" }}
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $serverLimits "cpu" | default "500m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $serverLimits "memory" | default "256Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $serverLimits "cpu" | default "{{ $.Values.gitops.server.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $serverLimits "memory" | default "{{ $.Values.gitops.server.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $serverRequests "cpu" | default "125m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $serverRequests "memory" | default "128Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $serverRequests "cpu" | default "{{ $.Values.gitops.server.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $serverRequests "memory" | default "{{ $.Values.gitops.server.requests.memory }}" {{ "hub}}" }}
                     route:
                       enabled: true
                   monitoring:
@@ -161,11 +163,11 @@ spec:
                     dex:
                       resources:
                         limits:
-                          cpu: {{ "{{hub" }} index $dexLimits "cpu" | default "500m" {{ "hub}}" }}
-                          memory: {{ "{{hub" }} index $dexLimits "memory" | default "256Mi" {{ "hub}}" }}
+                          cpu: {{ "{{hub" }} index $dexLimits "cpu" | default "{{ $.Values.gitops.dex.limits.cpu }}" {{ "hub}}" }}
+                          memory: {{ "{{hub" }} index $dexLimits "memory" | default "{{ $.Values.gitops.dex.limits.memory }}" {{ "hub}}" }}
                         requests:
-                          cpu: {{ "{{hub" }} index $dexRequests "cpu" | default "125m" {{ "hub}}" }}
-                          memory: {{ "{{hub" }} index $dexRequests "memory" | default "128Mi" {{ "hub}}" }}
+                          cpu: {{ "{{hub" }} index $dexRequests "cpu" | default "{{ $.Values.gitops.dex.requests.cpu }}" {{ "hub}}" }}
+                          memory: {{ "{{hub" }} index $dexRequests "memory" | default "{{ $.Values.gitops.dex.requests.memory }}" {{ "hub}}" }}
                       openShiftOAuth: true
                     provider: dex
                   rbac:
@@ -175,13 +177,17 @@ spec:
                     policy: {{ "{{hub" }} $rbac | toJson {{ "hub}}" }}
                     scopes: '[groups]'
                   repo:
+                    # Multiple replicas so PolicyGenerator CMP renders spread across pods when the
+                    # ApplicationSet fans out to every policies/* at once (a single repo-server
+                    # thrashes and renders time out).
+                    replicas: {{ "{{hub" }} index $repo "replicas" | default {{ $.Values.gitops.repo.replicas }} {{ "hub}}" }}
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $repoLimits "cpu" | default "2000m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $repoLimits "memory" | default "2048Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $repoLimits "cpu" | default "{{ $.Values.gitops.repo.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $repoLimits "memory" | default "{{ $.Values.gitops.repo.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $repoRequests "cpu" | default "500m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $repoRequests "memory" | default "512Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $repoRequests "cpu" | default "{{ $.Values.gitops.repo.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $repoRequests "memory" | default "{{ $.Values.gitops.repo.requests.memory }}" {{ "hub}}" }}
                     {{ "{{hub-" }} if $pgEnabled {{ "hub}}" }}
                     env:
                       - name: POLICY_GEN_ENABLE_HELM
@@ -239,7 +245,7 @@ spec:
                       - name: policy-generator
                         mountPath: /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
                       {{ "{{hub-" }} end {{ "hub}}" }}
-                      {{ "{{hub-" }} if eq (index .ManagedClusterLabels "autoshift.io/gitops-cluster-ca-bundle" | default (printf "%v" (index $repo "cluster_ca_bundle" | default false))) "true" {{ "hub}}" }}
+                      {{ "{{hub-" }} if eq (index .ManagedClusterLabels "autoshift.io/gitops-cluster-ca-bundle" | default (printf "%v" (ternary (index $repo "cluster_ca_bundle") {{ $.Values.gitops.repo.cluster_ca_bundle }} (hasKey $repo "cluster_ca_bundle")))) "true" {{ "hub}}" }}
                       - name: user-ca-bundle
                         mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
                         subPath: ca-bundle.crt
@@ -254,7 +260,7 @@ spec:
                       - name: cmp-tmp
                         emptyDir: {}
                       {{ "{{hub-" }} end {{ "hub}}" }}
-                      {{ "{{hub-" }} if eq (index .ManagedClusterLabels "autoshift.io/gitops-cluster-ca-bundle" | default (printf "%v" (index $repo "cluster_ca_bundle" | default false))) "true" {{ "hub}}" }}
+                      {{ "{{hub-" }} if eq (index .ManagedClusterLabels "autoshift.io/gitops-cluster-ca-bundle" | default (printf "%v" (ternary (index $repo "cluster_ca_bundle") {{ $.Values.gitops.repo.cluster_ca_bundle }} (hasKey $repo "cluster_ca_bundle")))) "true" {{ "hub}}" }}
                       - name: user-ca-bundle
                         configMap:
                           name: user-ca-bundle
@@ -262,39 +268,39 @@ spec:
                   ha:
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $haLimits "cpu" | default "500m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $haLimits "memory" | default "256Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $haLimits "cpu" | default "{{ $.Values.gitops.ha.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $haLimits "memory" | default "{{ $.Values.gitops.ha.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $haRequests "cpu" | default "125m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $haRequests "memory" | default "128Mi" {{ "hub}}" }}
-                    enabled: {{ "{{hub" }} index $ha "enabled" | default "false" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $haRequests "cpu" | default "{{ $.Values.gitops.ha.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $haRequests "memory" | default "{{ $.Values.gitops.ha.requests.memory }}" {{ "hub}}" }}
+                    enabled: {{ "{{hub" }} ternary (index $ha "enabled") {{ $.Values.gitops.ha.enabled }} (hasKey $ha "enabled") {{ "hub}}" }}
                   redis:
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $redisLimits "cpu" | default "500m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $redisLimits "memory" | default "256Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $redisLimits "cpu" | default "{{ $.Values.gitops.redis.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $redisLimits "memory" | default "{{ $.Values.gitops.redis.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $redisRequests "cpu" | default "125m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $redisRequests "memory" | default "128Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $redisRequests "cpu" | default "{{ $.Values.gitops.redis.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $redisRequests "memory" | default "{{ $.Values.gitops.redis.requests.memory }}" {{ "hub}}" }}
                   controller:
                     processors:
-                      status: {{ "{{hub" }} index $controller "statusProcessors" | default 20 {{ "hub}}" }}
-                      operation: {{ "{{hub" }} index $controller "operationProcessors" | default 10 {{ "hub}}" }}
+                      status: {{ "{{hub" }} index $controller "statusProcessors" | default {{ $.Values.gitops.controller.statusProcessors }} {{ "hub}}" }}
+                      operation: {{ "{{hub" }} index $controller "operationProcessors" | default {{ $.Values.gitops.controller.operationProcessors }} {{ "hub}}" }}
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default "2000m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default "4096Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $controllerLimits "cpu" | default "{{ $.Values.gitops.controller.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerLimits "memory" | default "{{ $.Values.gitops.controller.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default "250m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $controllerRequests "memory" | default "1024Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $controllerRequests "cpu" | default "{{ $.Values.gitops.controller.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $controllerRequests "memory" | default "{{ $.Values.gitops.controller.requests.memory }}" {{ "hub}}" }}
                   applicationSet:
                     resources:
                       limits:
-                        cpu: {{ "{{hub" }} index $applicationSetLimits "cpu" | default "2" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $applicationSetLimits "memory" | default "1Gi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $applicationSetLimits "cpu" | default "{{ $.Values.gitops.applicationSet.limits.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $applicationSetLimits "memory" | default "{{ $.Values.gitops.applicationSet.limits.memory }}" {{ "hub}}" }}
                       requests:
-                        cpu: {{ "{{hub" }} index $applicationSetRequests "cpu" | default "250m" {{ "hub}}" }}
-                        memory: {{ "{{hub" }} index $applicationSetRequests "memory" | default "512Mi" {{ "hub}}" }}
+                        cpu: {{ "{{hub" }} index $applicationSetRequests "cpu" | default "{{ $.Values.gitops.applicationSet.requests.cpu }}" {{ "hub}}" }}
+                        memory: {{ "{{hub" }} index $applicationSetRequests "memory" | default "{{ $.Values.gitops.applicationSet.requests.memory }}" {{ "hub}}" }}
                   resourceHealthChecks:
                     - group: policy.open-cluster-management.io
                       kind: Policy

--- a/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
+++ b/policies/stable/openshift-gitops/templates/policy-gitops-systems-argocd.yaml
@@ -104,6 +104,7 @@ spec:
             {{ "{{hub-" }} $pgSidecar := (index $infra "policyGenerator" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $pgSidecarLimits := (index $pgSidecar "limits" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $pgSidecarRequests := (index $pgSidecar "requests" | default dict) {{ "hub}}" }}
+            {{ "{{hub-" }} $pgTarExclusions := (index $pgSidecar "tarExclusions" | default (list{{ range $.Values.gitops.policyGenerator.tarExclusions }} {{ . | quote }}{{ end }})) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSet := (index $infra "applicationSet" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSetLimits := (index $applicationSet "limits" | default dict) {{ "hub}}" }}
             {{ "{{hub-" }} $applicationSetRequests := (index $applicationSet "requests" | default dict) {{ "hub}}" }}
@@ -188,6 +189,17 @@ spec:
                     # every policies/* at once. Without it the repo-server only pulls prerendered
                     # Helm charts, so one pod is enough.
                     replicas: {{ "{{hub" }} index $repo "replicas" | default (ternary {{ $.Values.gitops.policyGenerator.repo.replicas }} {{ $.Values.gitops.repo.replicas }} $pgEnabled) {{ "hub}}" }}
+                    {{ "{{hub-" }} if $pgEnabled {{ "hub}}" }}
+                    # Trim the tarball streamed to the CMP sidecar on every render.
+                    extraRepoCommandArgs:
+                      {{ "{{hub-" }} range $pgTarExclusions {{ "hub}}" }}
+                      - --plugin-tar-exclude
+                      - {{ "{{hub" }} . | quote {{ "hub}}" }}
+                      {{ "{{hub-" }} end {{ "hub}}" }}
+                      {{ "{{hub-" }} if (index $pgSidecar "useManifestGeneratePaths" | default {{ $.Values.gitops.policyGenerator.useManifestGeneratePaths }}) {{ "hub}}" }}
+                      - --plugin-use-manifest-generate-paths
+                      {{ "{{hub-" }} end {{ "hub}}" }}
+                    {{ "{{hub-" }} end {{ "hub}}" }}
                     resources:
                       limits:
                         cpu: {{ "{{hub" }} index $repoLimits "cpu" | default "{{ $.Values.gitops.repo.limits.cpu }}" {{ "hub}}" }}

--- a/policies/stable/openshift-gitops/values.yaml
+++ b/policies/stable/openshift-gitops/values.yaml
@@ -19,9 +19,46 @@ gitops:
     # mode (renders PolicyGenerator dirs live); disabled for OCI-only deployments (prerendered Helm).
     # The ApplicationSet forwards the effective value from the deployment's policyGenerator flag.
     enabled: true
+    repo:
+      # PolicyGenerator rendering (kustomize --enable-helm plus a nested Helm render) is heavy, so
+      # spread it across pods instead of thrashing a single repo-server when the ApplicationSet
+      # fans out to every policies/* at once.
+      replicas: 3
+    controller:
+      # Source mode fans the ApplicationSet out to an Application per policies/* directory, which
+      # drives the application controller far harder than consuming prerendered charts does. The
+      # controller OOMKills below this.
+      limits:
+        cpu: 2000m
+        memory: 6Gi
+      requests:
+        cpu: 250m
+        memory: 6Gi
+    # The CMP sidecar's own container resources. It runs the actual kustomize/PolicyGenerator/Helm
+    # render, so it needs real CPU; without resources it competes unbounded and renders time out
+    # under fan-out load. Override per cluster with config.gitops.infra.policyGenerator.
+    limits:
+      cpu: 2000m
+      memory: 2048Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi
   # Dev team cluster-scoped namespaces are auto-discovered from managed cluster labels
   # matching autoshift.io/gitops-dev-team-<team>-cluster-scoped: 'true'
+  # Argo CD RBAC. A `g` line assigns a subject to a role; the subject may be a user or a group. What
+  # makes groups the practical unit is the identity: scopes is '[groups]', checked alongside the
+  # always-matched sub claim, and with OpenShift login sub is an opaque Dex identifier rather than a
+  # username. Naming a user means pasting that opaque value.
+  #   system:cluster-admins - carried by kubeadmin (kube:admin)
+  #   cluster-admins        - the group Red Hat's OpenShift login procedure creates:
+  #                           oc adm groups new cluster-admins
+  # defaultPolicy is empty, so this list is the only access apart from the built-in admin account.
+  # Overridable per cluster with config.gitops.infra.rbac_policies, which REPLACES this list rather
+  # than appending to it. Avoid names containing commas (an LDAP group DN) - the comma is the field
+  # separator and the line is rejected as an invalid RBAC policy.
   rbac_policies:
+  - 'g, system:cluster-admins, role:admin'
+  - 'g, cluster-admins, role:admin'
   - 'g, openshift-systems, role:admin'
   # OPTIONAL
   controller:
@@ -31,10 +68,10 @@ gitops:
     operationProcessors: 10     # concurrent sync operations (default: 10)
     limits:
       cpu: 2000m
-      memory: 6Gi
+      memory: 2048Mi
     requests:
       cpu: 250m
-      memory: 6Gi
+      memory: 1024Mi
   ha:
     enabled: false
     limits:
@@ -55,9 +92,9 @@ gitops:
     # enabling the cluster_ca_bundle will inject the cluster's trusted CA bundle into the repo
     # server that Argo CD uses. This allows Argo CD to connect to repositories using custom certificates.
     cluster_ca_bundle: false
-    # Multiple replicas so PolicyGenerator CMP renders spread across pods when the ApplicationSet
-    # fans out to every policies/* at once (a single repo-server thrashes and renders time out).
-    replicas: 3
+    # Repo-server replicas WITHOUT the PolicyGenerator CMP: the repo-server only pulls prerendered
+    # Helm charts, so one pod is enough. The heavier source-mode count is policyGenerator.repo.replicas.
+    replicas: 1
     limits:
       cpu: 2000m
       memory: 2048Mi

--- a/policies/stable/openshift-gitops/values.yaml
+++ b/policies/stable/openshift-gitops/values.yaml
@@ -19,21 +19,6 @@ gitops:
     # mode (renders PolicyGenerator dirs live); disabled for OCI-only deployments (prerendered Helm).
     # The ApplicationSet forwards the effective value from the deployment's policyGenerator flag.
     enabled: true
-    repo:
-      # PolicyGenerator rendering (kustomize --enable-helm plus a nested Helm render) is heavy, so
-      # spread it across pods instead of thrashing a single repo-server when the ApplicationSet
-      # fans out to every policies/* at once.
-      replicas: 3
-    controller:
-      # Source mode fans the ApplicationSet out to an Application per policies/* directory, which
-      # drives the application controller far harder than consuming prerendered charts does. The
-      # controller OOMKills below this.
-      limits:
-        cpu: 2000m
-        memory: 6Gi
-      requests:
-        cpu: 250m
-        memory: 6Gi
     # Excluded from the repository tarball the repo-server streams to a CMP sidecar. This setting is
     # repo-server WIDE, so it hits every plugin-rendered Application on this Argo CD, not just
     # AutoShift's. Only .git is listed because no repository serves manifests out of it; do not add
@@ -58,8 +43,6 @@ gitops:
     requests:
       cpu: 500m
       memory: 512Mi
-  # Dev team cluster-scoped namespaces are auto-discovered from managed cluster labels
-  # matching autoshift.io/gitops-dev-team-<team>-cluster-scoped: 'true'
   # Argo CD RBAC. A `g` line assigns a subject to a role; the subject may be a user or a group. What
   # makes groups the practical unit is the identity: scopes is '[groups]', checked alongside the
   # always-matched sub claim, and with OpenShift login sub is an opaque Dex identifier rather than a
@@ -79,14 +62,22 @@ gitops:
   controller:
     # Scaling: increase processors for environments with many Applications
     # Recommended: 50 status / 25 operation for 1000+ Applications
-    statusProcessors: 20        # concurrent status reconciliations (default: 20)
-    operationProcessors: 10     # concurrent sync operations (default: 10)
+    # AutoShift generates an Application per policy directory, so even a minimal hub carries dozens.
+    # Measured on a 51-Application hub: a full refresh took 141s at 50/25 against 225s at the Argo CD
+    # defaults of 20/10, for 640Mi of controller memory. Raise further for a much larger policy set.
+    statusProcessors: 50        # concurrent status reconciliations (Argo CD default: 20)
+    operationProcessors: 25     # concurrent sync operations (Argo CD default: 10)
+    # Measured peak 843Mi on a hub with 51 Applications and 194 Policies at 50 processors, during a
+    # full hard-refresh storm. Requests sized for steady state and limits for that storm with room to
+    # spare; deliberately NOT equal, so the pod is Burstable and does not reserve the ceiling. A hub
+    # running several AutoShift deployments multiplies the per-Application share but not the cluster
+    # cache, which is the larger half. Re-measure before lowering rather than assuming.
     limits:
       cpu: 2000m
-      memory: 2048Mi
+      memory: 4Gi
     requests:
       cpu: 250m
-      memory: 1024Mi
+      memory: 1Gi
   ha:
     enabled: false
     limits:
@@ -107,8 +98,11 @@ gitops:
     # enabling the cluster_ca_bundle will inject the cluster's trusted CA bundle into the repo
     # server that Argo CD uses. This allows Argo CD to connect to repositories using custom certificates.
     cluster_ca_bundle: false
-    # Repo-server replicas WITHOUT the PolicyGenerator CMP: the repo-server only pulls prerendered
-    # Helm charts, so one pod is enough. The heavier source-mode count is policyGenerator.repo.replicas.
+    # Repo-server replicas. One is enough: with useManifestGeneratePaths each render ships only a
+    # policy's own directory, and a measured 51-Application refresh took 199s on one replica against
+    # 225s on three, with the repo-server idle at 14m CPU either way. The bottleneck is the
+    # application controller, not this. Raise it for availability or a much larger policy set, here
+    # or per cluster with config.gitops.infra.repo.replicas.
     replicas: 1
     limits:
       cpu: 2000m

--- a/policies/stable/openshift-gitops/values.yaml
+++ b/policies/stable/openshift-gitops/values.yaml
@@ -77,6 +77,7 @@ gitops:
     autoscale:
       enabled: true
       maxReplicas: 5
+      targetCPUUtilizationPercentage: 50
     limits:
       cpu: 500m
       memory: 256Mi
@@ -90,6 +91,13 @@ gitops:
     requests:
       cpu: 250m
       memory: 128Mi
+  applicationSet:
+    limits:
+      cpu: '2'
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi
 
 # hubClusterSets:
 #   hub:

--- a/policies/stable/openshift-gitops/values.yaml
+++ b/policies/stable/openshift-gitops/values.yaml
@@ -34,6 +34,21 @@ gitops:
       requests:
         cpu: 250m
         memory: 6Gi
+    # Excluded from the repository tarball the repo-server streams to a CMP sidecar. This setting is
+    # repo-server WIDE, so it hits every plugin-rendered Application on this Argo CD, not just
+    # AutoShift's. Only .git is listed because no repository serves manifests out of it; do not add
+    # generic names like docs/ or scripts/ unless this Argo CD serves AutoShift alone, or another
+    # team's plugin app that keeps manifests there will silently render empty. AutoShift scopes its
+    # own tarball per Application with useManifestGeneratePaths below instead.
+    # Go filepath.Match syntax, one --plugin-tar-exclude repo-server arg per entry.
+    tarExclusions:
+      - '.git/*'
+    # Honour the argocd.argoproj.io/manifest-generate-paths annotation, which the AutoShift
+    # ApplicationSet stamps on every generated policy Application so each one ships only its own
+    # directory plus components/ rather than the whole repository. Verified on a live hub: the flag
+    # is inert for Applications that do not carry the annotation, so other workloads on this Argo CD
+    # are unaffected.
+    useManifestGeneratePaths: true
     # The CMP sidecar's own container resources. It runs the actual kustomize/PolicyGenerator/Helm
     # render, so it needs real CPU; without resources it competes unbounded and renders time out
     # under fan-out load. Override per cluster with config.gitops.infra.policyGenerator.

--- a/tools/internal/resolver/object_templates_raw_test.go
+++ b/tools/internal/resolver/object_templates_raw_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package resolver
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/auto-shift/autoshiftv2/tools/internal/labels"
+)
+
+// TestObjectTemplatesRaw_ParsesAsYAML closes a gap in the end-to-end pipeline: that
+// test validates the resolved Policy document, but an object-templates-raw block is
+// a *string* at that level, so whatever YAML it contains is never parsed. A raw block
+// can therefore be structurally broken while the Policy around it stays perfectly
+// valid.
+//
+// The failure that motivated this: an unquoted `key: {{hub … | toLiteral hub}}`
+// swallows the newline after it, so the next key lands on the same line
+// (`secrets: [...]remoteWrite:`). The Policy still parses; the object the policy
+// actually applies does not.
+//
+// Blocks that still contain Go template markers after resolution are skipped — they
+// are meant to be evaluated later, on the managed cluster.
+func TestObjectTemplatesRaw_ParsesAsYAML(t *testing.T) {
+	root := repoRoot(t)
+	policiesDir := filepath.Join(root, "policies")
+	valuesDir := filepath.Join(root, "autoshift", "values")
+	testdataDir := filepath.Join(root, "tools", "testdata")
+
+	declared, err := labels.ExtractDeclaredFromTree(valuesDir, false)
+	if err != nil {
+		t.Fatalf("ExtractDeclaredFromTree: %v", err)
+	}
+	ctx := HubContext{
+		ManagedClusterName:   "lint-cluster",
+		ManagedClusterLabels: BuildSyntheticLabels(declared),
+	}
+	configs, err := ExtractExampleConfigs(valuesDir)
+	if err != nil {
+		t.Fatalf("ExtractExampleConfigs: %v", err)
+	}
+	syntheticCMs, err := GenerateSyntheticConfigMaps(configs, ctx.ManagedClusterName, "policies-autoshift")
+	if err != nil {
+		t.Fatalf("GenerateSyntheticConfigMaps: %v", err)
+	}
+	testResources, err := LoadTestResources(testdataDir)
+	if err != nil {
+		t.Fatalf("LoadTestResources: %v", err)
+	}
+	seed := append(syntheticCMs, testResources...)
+	r, err := NewResolver(seed)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	spokeR, err := NewSpokeResolver(seed)
+	if err != nil {
+		t.Fatalf("NewSpokeResolver: %v", err)
+	}
+	_, results, err := RunPipeline(policiesDir, ctx, nil, r, spokeR, declared, configs, testdataDir)
+	if err != nil {
+		t.Fatalf("RunPipeline: %v", err)
+	}
+
+	checked, skipped, failures := 0, 0, 0
+	for _, res := range results {
+		if res.Err != nil || res.ResolvedYAML == "" {
+			continue
+		}
+		dec := yaml.NewDecoder(strings.NewReader(res.ResolvedYAML))
+		for {
+			var doc map[string]any
+			if err := dec.Decode(&doc); err != nil {
+				break // end of stream, or a doc the e2e test already reports on
+			}
+			if doc == nil || doc["kind"] != "Policy" {
+				continue
+			}
+			policyName, _ := nested(doc, "metadata", "name").(string)
+			spec, _ := doc["spec"].(map[string]any)
+			templates, _ := spec["policy-templates"].([]any)
+			for _, pt := range templates {
+				ptm, _ := pt.(map[string]any)
+				od, _ := ptm["objectDefinition"].(map[string]any)
+				odSpec, _ := od["spec"].(map[string]any)
+				raw, ok := odSpec["object-templates-raw"].(string)
+				if !ok || strings.TrimSpace(raw) == "" {
+					continue
+				}
+				if strings.Contains(raw, "{{") {
+					skipped++
+					continue
+				}
+				checked++
+				var items []map[string]any
+				if err := yaml.Unmarshal([]byte(raw), &items); err != nil {
+					failures++
+					t.Errorf("%s: policy %s: object-templates-raw is not parseable YAML: %v\n--- block ---\n%s",
+						res.Policy, policyName, err, indent(raw))
+					continue
+				}
+				for i, it := range items {
+					if _, has := it["objectDefinition"]; !has {
+						failures++
+						t.Errorf("%s: policy %s: object-templates-raw entry %d has no objectDefinition (keys: %v)",
+							res.Policy, policyName, i, keysOf(it))
+					}
+				}
+			}
+		}
+	}
+	t.Logf("object-templates-raw: %d blocks parsed, %d skipped (still templated), %d failures", checked, skipped, failures)
+	if checked == 0 {
+		t.Fatal("no object-templates-raw blocks were checked — the harness is not seeing resolved output")
+	}
+}
+
+func nested(m map[string]any, path ...string) any {
+	var cur any = m
+	for _, p := range path {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[p]
+	}
+	return cur
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func indent(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = "    " + l
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Description

The bootstrap chart and day-2 policy were reverting each other's sizing; both now read the same values. Render scoping takes a full refresh from ~5 min to 39s and the controller from 6Gi to 4Gi.

## Type of Change

- [ ] Bug fix (incorrect template, label logic, chart rendering)

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
