### PR TITLE
feat: add unschedulable-control-plane policy for compact clusters

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -807,6 +807,19 @@ hubClusterSets:
       aap-cabundle-name: 'user-ca-bundle'    # Secret name for CA Bundle
 
       # =======================================================================
+      # Unschedulable Control Plane (Compact clusters)
+      # =======================================================================
+      # Taints specific master nodes with NoSchedule so they run only control
+      # plane components. Useful for compact 5-node clusters where 4 masters
+      # should be schedulable and 1 should be dedicated to the control plane.
+      # Uses a custom taint key (autoshift.io/unschedulable-control-plane) to avoid
+      # conflicting with the OpenShift scheduler operator on compact clusters.
+      # System DaemonSets (networking, CSI, etc.) tolerate all taints and are
+      # unaffected.
+      unschedulable-control-plane: 'false'         # Enable unschedulable control plane tainting
+      # unschedulable-control-plane-node-1: 'master-4.my-cluster.example.com'  # Node(s) to taint
+
+      # =======================================================================
       # Master Node Kubelet Configuration (SNO / Compact clusters)
       # =======================================================================
       master-nodes: 'false'

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -817,7 +817,7 @@ hubClusterSets:
       # System DaemonSets (networking, CSI, etc.) tolerate all taints and are
       # unaffected.
       unschedulable-control-plane: 'false'         # Enable unschedulable control plane tainting
-      # unschedulable-control-plane-node: 'master-4.my-cluster.example.com'  # Prefix — append -1, -2, etc. for each node to taint
+      unschedulable-control-plane-node: ''            # Prefix — set -node-1, -node-2, etc. with node hostname as value
 
       # =======================================================================
       # Master Node Kubelet Configuration (SNO / Compact clusters)

--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -817,7 +817,7 @@ hubClusterSets:
       # System DaemonSets (networking, CSI, etc.) tolerate all taints and are
       # unaffected.
       unschedulable-control-plane: 'false'         # Enable unschedulable control plane tainting
-      # unschedulable-control-plane-node-1: 'master-4.my-cluster.example.com'  # Node(s) to taint
+      # unschedulable-control-plane-node: 'master-4.my-cluster.example.com'  # Prefix — append -1, -2, etc. for each node to taint
 
       # =======================================================================
       # Master Node Kubelet Configuration (SNO / Compact clusters)

--- a/docs/values-reference.md
+++ b/docs/values-reference.md
@@ -314,7 +314,59 @@ hubClusterSets:
 ```
 
 
-### Master nodes
+### Unschedulable Control Plane
+
+Taints specific master nodes with `NoSchedule` so they run only control plane components (etcd, API server, controllers, scheduler). Designed for compact clusters where most masters should remain schedulable but one or more should be marked unschedulable.
+
+**Why a custom taint key?** On compact clusters, the OpenShift scheduler operator has `mastersSchedulable: true` and actively removes the standard `node-role.kubernetes.io/control-plane:NoSchedule` taint. Using the standard key would create a reconciliation loop between ACM and the scheduler operator. The custom key `autoshift.io/unschedulable-control-plane` avoids this conflict entirely.
+
+**Impact on workloads:**
+- **Application workloads**: No changes needed. Pods without a toleration for the custom taint simply won't schedule on the dedicated node.
+- **System DaemonSets** (OVN-Kubernetes, CSI plugins, machine-config-daemon, etc.): Unaffected. These use `operator: Exists` tolerations that tolerate all taints.
+- **Control plane components** (etcd, API server, scheduler, controllers): Unaffected. These run as static pods with all-taint tolerations.
+
+| Variable                                | Type   | Default | Notes |
+|-----------------------------------------|--------|---------|-------|
+| `unschedulable-control-plane`               | bool   | `false` | Enable unschedulable control plane tainting |
+| `unschedulable-control-plane-node-[number]` | string |         | Node hostname to taint (e.g., `master-4.my-cluster.example.com`). Add additional nodes with `-node-2`, `-node-3`, etc. |
+
+**Example: 5-node compact cluster with 1 unschedulable control plane node**
+
+Install the cluster as a compact 5-node topology (`controlPlaneAgents: 5`, `workerAgents: 0`) so all masters are schedulable. Then use this policy to taint the node that should be dedicated:
+
+```yaml
+managedClusterSets:
+  my-clusters:
+    labels:
+      unschedulable-control-plane: 'true'
+      unschedulable-control-plane-node-1: 'master-4.my-cluster.example.com'
+```
+
+To also run ODF on the 4 schedulable nodes, combine with `storage-nodes` (baremetal) to label them explicitly:
+
+```yaml
+managedClusterSets:
+  my-clusters:
+    labels:
+      # Dedicated control plane
+      unschedulable-control-plane: 'true'
+      unschedulable-control-plane-node-1: 'master-4.my-cluster.example.com'
+      # Storage nodes (exclude the dedicated CP node)
+      storage-nodes: '4'
+      storage-nodes-provider: 'baremetal'
+      storage-nodes-node-1: 'master-0.my-cluster.example.com'
+      storage-nodes-node-2: 'master-1.my-cluster.example.com'
+      storage-nodes-node-3: 'master-2.my-cluster.example.com'
+      storage-nodes-node-4: 'master-3.my-cluster.example.com'
+      # Local storage + ODF
+      local-storage: 'true'
+      odf: 'true'
+      odf-resource-profile: 'lean'
+```
+
+ODF auto-enables `flexibleScaling` for 4 nodes (not a multiple of 3) and distributes OSDs across all 4 hosts.
+
+### Master Nodes
 
 Single Node OpenShift clusters as well as Compact Clusters have to rely on their master nodes to handle workloads. You may have to increase the number of pods per node in these resource constrained environments.
 

--- a/docs/values-reference.md
+++ b/docs/values-reference.md
@@ -321,7 +321,7 @@ Taints specific master nodes with `NoSchedule` so they run only control plane co
 **Why a custom taint key?** On compact clusters, the OpenShift scheduler operator has `mastersSchedulable: true` and actively removes the standard `node-role.kubernetes.io/control-plane:NoSchedule` taint. Using the standard key would create a reconciliation loop between ACM and the scheduler operator. The custom key `autoshift.io/unschedulable-control-plane` avoids this conflict entirely.
 
 **Impact on workloads:**
-- **Application workloads**: No changes needed. Pods without a toleration for the custom taint simply won't schedule on the dedicated node.
+- **Application workloads**: No changes needed. Pods without a toleration for the custom taint simply will not schedule on the dedicated node.
 - **System DaemonSets** (OVN-Kubernetes, CSI plugins, machine-config-daemon, etc.): Unaffected. These use `operator: Exists` tolerations that tolerate all taints.
 - **Control plane components** (etcd, API server, scheduler, controllers): Unaffected. These run as static pods with all-taint tolerations.
 

--- a/policies/stable/unschedulable-control-plane/kustomization.yaml
+++ b/policies/stable/unschedulable-control-plane/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - policy-generator-config.yaml

--- a/policies/stable/unschedulable-control-plane/manifests/unschedulable-control-plane-taint.yaml
+++ b/policies/stable/unschedulable-control-plane/manifests/unschedulable-control-plane-taint.yaml
@@ -1,0 +1,21 @@
+object-templates-raw: |
+  {{hub- $node_list := list hub}}
+  {{hub- range $label, $labelvalue := .ManagedClusterLabels hub}}
+    {{hub- if $label | hasPrefix "autoshift.io/unschedulable-control-plane-node" hub}}
+      {{hub- $node_list = append $node_list $labelvalue hub}}
+    {{hub- end hub}}
+  {{hub- end hub}}
+
+  {{- range (list
+    {{hub range $node_list hub}} {{hub . | quote hub}} {{hub end hub}}) }}
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: {{ . }}
+      spec:
+        taints:
+          - key: autoshift.io/unschedulable-control-plane
+            effect: NoSchedule
+  {{- end }}

--- a/policies/stable/unschedulable-control-plane/placement.yaml
+++ b/policies/stable/unschedulable-control-plane/placement.yaml
@@ -1,0 +1,20 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-policy-unschedulable-control-plane
+  namespace: ${POLICY_NAMESPACE}
+spec:
+  # No spec.clusterSets: selected via ManagedClusterSetBindings in this namespace + the predicate.
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: 'autoshift.io/unschedulable-control-plane'
+              operator: In
+              values:
+                - 'true'
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists

--- a/policies/stable/unschedulable-control-plane/policy-generator-config.yaml
+++ b/policies/stable/unschedulable-control-plane/policy-generator-config.yaml
@@ -1,0 +1,35 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: unschedulable-control-plane
+# Per-deployment scalars (${...}) are substituted by the repo-server CMP (envsubst/sed) BEFORE
+# `kustomize build` runs. They live here and in placement.yaml — never in manifests/, whose hub
+# templates contain `$vars` that substitution would clobber.
+#
+# manifests[].path is a single FILE here; a DIRECTORY would wildcard the whole dir. Only edit this
+# file to change the policy graph itself (names, dependencies, per-policy remediation). Keep
+# placement.yaml OUT of manifests/ (a Placement inside a wildcarded dir would be wrapped into the
+# Policy as a managed object).
+policyDefaults:
+  namespace: ${POLICY_NAMESPACE}
+  # ${REMEDIATION} = inform when autoshift.dryRun, else enforce.
+  remediationAction: ${REMEDIATION}
+  severity: high
+  consolidateManifests: true
+  evaluationInterval:
+    compliant: ${EVAL_COMPLIANT}
+    noncompliant: ${EVAL_NONCOMPLIANT}
+  standards:
+    - ${POLICY_STANDARD}
+  categories:
+    - CM Configuration Management
+  controls:
+    - CM-2 Baseline Configuration
+  # Placement authored by us (placement.yaml at the dir root, full fidelity); PG includes it and
+  # generates only the PlacementBinding.
+  placement:
+    placementPath: placement.yaml
+policies:
+  - name: policy-unschedulable-control-plane
+    manifests:
+      - path: manifests/unschedulable-control-plane-taint.yaml


### PR DESCRIPTION
## Summary

- Add a new `unschedulable-control-plane` policy that taints specific master nodes with `autoshift.io/unschedulable-control-plane: NoSchedule` so they run only control plane components.
- Designed for compact cluster topologies (e.g., [dual-room ACP](https://github.com/RedHatEdge/patterns/tree/main/patterns/dual-room-acp-topology#approach-a-stretched-acp)) where most masters should remain schedulable but one or more should be dedicated to control plane workloads.
- Uses a custom taint key (`autoshift.io/unschedulable-control-plane`) to avoid reconciliation loops with the OpenShift scheduler operator, which actively removes the standard `node-role.kubernetes.io/control-plane:NoSchedule` taint on compact clusters with `mastersSchedulable: true`.
- Node list is driven by labels matching `unschedulable-control-plane-node-[number]` — supports any number of nodes.
- Gated by `unschedulable-control-plane: 'true'` label.
- Includes documentation in `values-reference.md` with a 5-node compact cluster example showing combined use with ODF storage nodes.

## Test plan

- [x] Deploy with `unschedulable-control-plane: 'true'` and one node label — verify taint is applied
- [ ] Deploy with multiple node labels — verify all listed nodes are tainted
- [x] Verify system DaemonSets (OVN, CSI, MCO) continue running on tainted nodes (they use `operator: Exists` tolerations)
- [ ] Verify application workloads are not scheduled on tainted nodes
- [x] Deploy without the label — verify policy does not target the cluster

## Validation (2026-09-04, compact-acp cluster — 3-node compact, OCP 4.22.6)

**Hub labels on ManagedCluster `compact-acp`:**
- `autoshift.io/unschedulable-control-plane: "true"`
- `autoshift.io/unschedulable-control-plane-node-0: snuc2.compact-acp.basementinnovation.center`

**Hub policy:** `policy-unschedulable-control-plane` — **Compliant** on `compact-acp`
**Policy status message:** `Compliant; notification - nodes [snuc2.compact-acp.basementinnovation.center] found as specified`

**Spoke node taints (compact-acp):**
| Node | `autoshift.io/unschedulable-control-plane` |
|---|---|
| snuc0 (node0) | *not present* |
| snuc1 (node1) | *not present* |
| snuc2 (node2) | `NoSchedule` |

Only the labeled node (`snuc2`) received the taint — the other two masters remain fully schedulable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)