### PR TITLE
Fix acm memory tuning and extra namespace creation

### DIFF
--- a/autoshift/values/clustersets/_example.yaml
+++ b/autoshift/values/clustersets/_example.yaml
@@ -926,10 +926,12 @@ hubClusterSets:
       acm-addon-gpf-eval-concurrency: '5'    # Concurrent policy evaluations (default: 2)
       acm-addon-gpf-client-qps: '75'         # K8s API client QPS (default: 30)
       acm-addon-gpf-client-burst: '100'      # K8s API client burst (default: 45)
-      # governance-policy-framework resource limits (via AddOnDeploymentConfig)
-      acm-addon-gpf-mem-request: '128Mi'
+      # governance-policy-framework resource limits (via AddOnDeploymentConfig).
+      # Keep at 1Gi or above: the addon OOMKills around 100 ConfigurationPolicies, and it
+      # delivers its own tuning, so it cannot raise the limit once it does.
+      acm-addon-gpf-mem-request: '256Mi'
       acm-addon-gpf-cpu-request: '100m'
-      acm-addon-gpf-mem-limit: '512Mi'
+      acm-addon-gpf-mem-limit: '1Gi'
 
       # =======================================================================
       # Tempo

--- a/autoshift/values/clustersets/hub.yaml
+++ b/autoshift/values/clustersets/hub.yaml
@@ -92,10 +92,12 @@ hubClusterSets:
       acm-addon-gpf-eval-concurrency: '5'    # Concurrent policy evaluations (default: 2)
       acm-addon-gpf-client-qps: '75'         # K8s API client QPS (default: 30)
       acm-addon-gpf-client-burst: '100'      # K8s API client burst (default: 45)
-      # governance-policy-framework resource limits (via AddOnDeploymentConfig)
-      acm-addon-gpf-mem-request: '128Mi'
+      # governance-policy-framework resource limits (via AddOnDeploymentConfig).
+      # Keep at 1Gi or above: the addon OOMKills around 100 ConfigurationPolicies, and it
+      # delivers its own tuning, so it cannot raise the limit once it does.
+      acm-addon-gpf-mem-request: '256Mi'
       acm-addon-gpf-cpu-request: '100m'
-      acm-addon-gpf-mem-limit: '512Mi'
+      acm-addon-gpf-mem-limit: '1Gi'
       ### User Workload Monitoring
       uwm: 'true'
       ### node-maintenance

--- a/docs/values-reference.md
+++ b/docs/values-reference.md
@@ -189,9 +189,9 @@ created for each replica of the image service. Sized to hold the image catalog: 
 | `acm-addon-gpf-eval-concurrency` | string | `5`                  | governance-policy-framework concurrent policy evaluations (default: 2) |
 | `acm-addon-gpf-client-qps`  | string    | `75`                     | governance-policy-framework K8s API client QPS (default: 30) |
 | `acm-addon-gpf-client-burst` | string   | `100`                    | governance-policy-framework K8s API client burst (default: 45) |
-| `acm-addon-gpf-mem-request`  | string   | `128Mi`                  | governance-policy-framework memory request |
+| `acm-addon-gpf-mem-request`  | string   | `256Mi`                  | governance-policy-framework memory request |
 | `acm-addon-gpf-cpu-request`  | string   | `100m`                   | governance-policy-framework CPU request |
-| `acm-addon-gpf-mem-limit`    | string   | `512Mi`                  | governance-policy-framework memory limit |
+| `acm-addon-gpf-mem-limit`    | string   | `1Gi`                    | governance-policy-framework memory limit. The add-on delivers its own tuning, so an OOMKilled one has to be patched by hand |
 
 **Config block** (`config.acm.provisioning`):
 

--- a/policies/stable/advanced-cluster-management/manifests/addon-tuning/acm-addon-governance-framework-resources.yaml
+++ b/policies/stable/advanced-cluster-management/manifests/addon-tuning/acm-addon-governance-framework-resources.yaml
@@ -8,7 +8,7 @@ spec:
   - containerID: deployments:governance-policy-framework:governance-policy-framework-addon
     resources:
       requests:
-        memory: '{{hub index .ManagedClusterLabels "autoshift.io/acm-addon-gpf-mem-request" | default "128Mi" hub}}'
+        memory: '{{hub index .ManagedClusterLabels "autoshift.io/acm-addon-gpf-mem-request" | default "256Mi" hub}}'
         cpu: '{{hub index .ManagedClusterLabels "autoshift.io/acm-addon-gpf-cpu-request" | default "100m" hub}}'
       limits:
-        memory: '{{hub index .ManagedClusterLabels "autoshift.io/acm-addon-gpf-mem-limit" | default "512Mi" hub}}'
+        memory: '{{hub index .ManagedClusterLabels "autoshift.io/acm-addon-gpf-mem-limit" | default "1Gi" hub}}'

--- a/policies/stable/advanced-cluster-management/manifests/operator-install/kustomization.yaml
+++ b/policies/stable/advanced-cluster-management/manifests/operator-install/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 # Renders the shared components/operator-install chart. ACM installs into open-cluster-management in
 # single-namespace (OwnNamespace) mode — its OperatorGroup scopes targetNamespaces to its own namespace.
-# It also creates the policy namespace (${POLICY_NAMESPACE}) as an extra namespace. The OperatorGroup name
-# is left to the component default (reuse an existing group in the namespace, else the namespace name).
+# It does NOT create the policy namespace. policy-foundation creates that on the cluster AutoShift is
+# deployed to, and on a managed hub the namespace belongs to that hub's own deployment, which is what
+# policy-managed-hub-namespace asserts. The OperatorGroup name is left to the component default (reuse
+# an existing group in the namespace, else the namespace name).
 helmGlobals:
   chartHome: ../../../../../components/
 helmCharts:
@@ -12,8 +14,6 @@ helmCharts:
     valuesInline:
       name: acm
       namespace: open-cluster-management
-      namespaces:
-        - ${POLICY_NAMESPACE}
       targetNamespaces:
         - open-cluster-management
       remediation: ${REMEDIATION}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] New policy (new operator or cluster configuration)
- [ ] Bug fix (incorrect template, label logic, chart rendering)
- [ ] Documentation update
- [ ] CI/tooling change
- [ ] Other: <!-- describe -->

## Checklist

- [ ] Policy generated using `generate-operator-policy.sh` or `generate-policy.sh` (if applicable)
- [ ] `helm template policies/stable/<name>/` renders without errors
- [ ] `cd tools && go test -tags integration ./...` passes
- [ ] New `autoshift.io/<key>` labels declared in `autoshift/values/clustersets/_example.yaml`
- [ ] `subscription-name`, `channel`, `source`, and `source-namespace` labels defined for any new operator
- [ ] Policy README.md included or updated
- [ ] No hardcoded values — hub templates used where cluster-specific values are needed
- [ ] Tested in a dev/sandbox environment
- [ ] Commits signed off with `git commit --signoff` (DCO)

## Related Issues

<!-- Closes #123 -->
